### PR TITLE
all: changes to fullsync the network from the nethermind import

### DIFF
--- a/core/vm/evm.go
+++ b/core/vm/evm.go
@@ -465,9 +465,9 @@ func (evm *EVM) create(caller ContractRef, codeAndHash *codeAndHash, gas uint64,
 	ret, err := evm.interpreter.Run(contract, nil, false)
 
 	// Check whether the max code size has been exceeded, assign err if the case.
-	if err == nil && evm.chainRules.IsEIP158 && len(ret) > params.MaxCodeSize {
-		err = ErrMaxCodeSizeExceeded
-	}
+	// if err == nil && evm.chainRules.IsEIP158 && len(ret) > params.MaxCodeSize {
+	// 	err = ErrMaxCodeSizeExceeded
+	// }
 
 	// Reject code starting with 0xEF if EIP-3541 is enabled.
 	if err == nil && len(ret) >= 1 && ret[0] == 0xEF && evm.chainRules.IsLondon {


### PR DESCRIPTION
This branch is rebased on top of go-ethereum's `master` in order to include withdrawals. It is meant to take the database generated by #1 and fullsync the network, in order to server snap sync data to other nodes (nethermind or geth, but the branch for the latter does not exist yet).

The import code has been removed, in order to keep the rebase + dependency management simpler. The nethermind DB importer need not be rebased, and so the branch will be left as-is.

Build and run:
```
go run  --syncmode=full --datadir=.gc --bootnodes=<bootnodes> --nat=extip:<public ip> --networkid 100
```