### PR TITLE
fix: add Osaka blob schedule params to Chiado and Gnosis chainspecs

### DIFF
--- a/params/chainspecs/chiado.json
+++ b/params/chainspecs/chiado.json
@@ -28,6 +28,11 @@
       "target": 1,
       "max": 2,
       "baseFeeUpdateFraction": 1112826
+    },
+    "osaka": {
+      "target": 1,
+      "max": 2,
+      "baseFeeUpdateFraction": 1112826
     }
   },
   "noPruneContracts": {

--- a/params/chainspecs/gnosis.json
+++ b/params/chainspecs/gnosis.json
@@ -33,6 +33,11 @@
       "target": 1,
       "max": 2,
       "baseFeeUpdateFraction": 1112826
+    },
+    "osaka": {
+      "target": 1,
+      "max": 2,
+      "baseFeeUpdateFraction": 1112826
     }
   },
   "depositContractAddress": "0x0B98057eA310F4d31F2a452B414647007d1645d9",


### PR DESCRIPTION
This PR adds the Osaka blob schedule params for both chiado and gnosis

I know that we are currently only have osaka on chiado but my understanding is we can add the blob params for gnosis now and update the osaka time when we are ready.