### PR TITLE
params/chainspecs: schedule osaka for gc

### DIFF
--- a/params/chainspecs/gnosis.json
+++ b/params/chainspecs/gnosis.json
@@ -16,6 +16,7 @@
   "cancunTime": 1710181820,
   "pragueTime": 1746021820,
   "balancerTime": 1766419900,
+  "osakaTime": 1776168380,
   "terminalTotalDifficulty": 8626000000000000000000058750000000000000000000,
   "terminalTotalDifficultyPassed": true,
   "blobSchedule": {


### PR DESCRIPTION
schedules osaka upgrade for gnosischain

See agreed-upon timestamp here: https://github.com/gnosischain/specs/pull/92

cc: @debjit-bw