### PR TITLE
params, core/state: fix tests, make gnosis-specific blob parameters configurable, ci passing

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -79,15 +79,7 @@ jobs:
           sudo apt-get -yq --no-install-suggests --no-install-recommends install gcc-multilib
 
       - name: Build
-        run: |
-          for attempt in 1 2 3; do
-            echo "Attempt $attempt"
-            if go run build/ci.go test -arch 386 -short; then
-              exit 0
-            fi
-            echo "Attempt $attempt failed"
-          done
-          exit 1
+        run: go run build/ci.go test -arch 386 -short
 
   test:
     name: Test

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -79,7 +79,15 @@ jobs:
           sudo apt-get -yq --no-install-suggests --no-install-recommends install gcc-multilib
 
       - name: Build
-        run: go run build/ci.go test -arch 386 -short
+        run: |
+          for attempt in 1 2 3; do
+            echo "Attempt $attempt"
+            if go run build/ci.go test -arch 386 -short; then
+              exit 0
+            fi
+            echo "Attempt $attempt failed"
+          done
+          exit 1
 
   test:
     name: Test

--- a/consensus/misc/eip4844/eip4844.go
+++ b/consensus/misc/eip4844/eip4844.go
@@ -29,10 +29,10 @@ import (
 // BlobConfig contains the parameters for blob-related formulas.
 // These can be adjusted in a fork.
 type BlobConfig struct {
-	Target           int
-	Max              int
-	UpdateFraction   uint64
-	MinBlobGasPrice  int64
+	Target          int
+	Max             int
+	UpdateFraction  uint64
+	MinBlobGasPrice int64
 }
 
 func (bc *BlobConfig) maxBlobGas() uint64 {

--- a/consensus/misc/eip4844/eip4844.go
+++ b/consensus/misc/eip4844/eip4844.go
@@ -32,7 +32,7 @@ type BlobConfig struct {
 	Target          int
 	Max             int
 	UpdateFraction  uint64
-	MinBlobGasPrice int64
+	MinBlobGasPrice uint64
 }
 
 func (bc *BlobConfig) maxBlobGas() uint64 {
@@ -41,7 +41,7 @@ func (bc *BlobConfig) maxBlobGas() uint64 {
 
 // blobBaseFee computes the blob fee.
 func (bc *BlobConfig) blobBaseFee(excessBlobGas uint64) *big.Int {
-	return fakeExponential(big.NewInt(bc.MinBlobGasPrice), new(big.Int).SetUint64(excessBlobGas), new(big.Int).SetUint64(bc.UpdateFraction))
+	return fakeExponential(new(big.Int).SetUint64(bc.MinBlobGasPrice), new(big.Int).SetUint64(excessBlobGas), new(big.Int).SetUint64(bc.UpdateFraction))
 }
 
 // blobPrice returns the price of one blob in Wei.
@@ -84,7 +84,7 @@ func latestBlobConfig(cfg *params.ChainConfig, time uint64) (BlobConfig, error) 
 		Target:          bc.Target,
 		Max:             bc.Max,
 		UpdateFraction:  bc.UpdateFraction,
-		MinBlobGasPrice: cfg.BlobScheduleConfig.GetMinBlobGasPrice(),
+		MinBlobGasPrice: cfg.GetMinBlobGasPrice(),
 	}, nil
 }
 

--- a/consensus/misc/eip4844/eip4844.go
+++ b/consensus/misc/eip4844/eip4844.go
@@ -26,16 +26,13 @@ import (
 	"github.com/ethereum/go-ethereum/params"
 )
 
-var (
-	minBlobGasPrice = big.NewInt(params.BlobTxMinBlobGasprice)
-)
-
 // BlobConfig contains the parameters for blob-related formulas.
 // These can be adjusted in a fork.
 type BlobConfig struct {
-	Target         int
-	Max            int
-	UpdateFraction uint64
+	Target           int
+	Max              int
+	UpdateFraction   uint64
+	MinBlobGasPrice  int64
 }
 
 func (bc *BlobConfig) maxBlobGas() uint64 {
@@ -44,7 +41,7 @@ func (bc *BlobConfig) maxBlobGas() uint64 {
 
 // blobBaseFee computes the blob fee.
 func (bc *BlobConfig) blobBaseFee(excessBlobGas uint64) *big.Int {
-	return fakeExponential(minBlobGasPrice, new(big.Int).SetUint64(excessBlobGas), new(big.Int).SetUint64(bc.UpdateFraction))
+	return fakeExponential(big.NewInt(bc.MinBlobGasPrice), new(big.Int).SetUint64(excessBlobGas), new(big.Int).SetUint64(bc.UpdateFraction))
 }
 
 // blobPrice returns the price of one blob in Wei.
@@ -84,9 +81,10 @@ func latestBlobConfig(cfg *params.ChainConfig, time uint64) (BlobConfig, error) 
 	}
 
 	return BlobConfig{
-		Target:         bc.Target,
-		Max:            bc.Max,
-		UpdateFraction: bc.UpdateFraction,
+		Target:          bc.Target,
+		Max:             bc.Max,
+		UpdateFraction:  bc.UpdateFraction,
+		MinBlobGasPrice: cfg.BlobScheduleConfig.GetMinBlobGasPrice(),
 	}, nil
 }
 

--- a/core/forkid/forkid.go
+++ b/core/forkid/forkid.go
@@ -292,13 +292,16 @@ func gatherForks(config *params.ChainConfig, genesis uint64) ([]uint64, []uint64
 	for len(forksByTime) > 0 && forksByTime[0] <= genesis {
 		forksByTime = forksByTime[1:]
 	}
-	// hack-insert the poa reward contract block
-	var hackedForksByBlock []uint64
-	for i := range forksByBlock {
-		if i > 0 && forksByBlock[i-1] < 9186425 && forksByBlock[i] > 9186425 {
-			hackedForksByBlock = append(hackedForksByBlock, 9186425)
+	// hack-insert the poa reward contract block (Gnosis chain ID 100 only)
+	if config.ChainID != nil && config.ChainID.Uint64() == 100 {
+		var hackedForksByBlock []uint64
+		for i := range forksByBlock {
+			if i > 0 && forksByBlock[i-1] < 9186425 && forksByBlock[i] > 9186425 {
+				hackedForksByBlock = append(hackedForksByBlock, 9186425)
+			}
+			hackedForksByBlock = append(hackedForksByBlock, forksByBlock[i])
 		}
-		hackedForksByBlock = append(hackedForksByBlock, forksByBlock[i])
+		return hackedForksByBlock, forksByTime
 	}
-	return hackedForksByBlock, forksByTime
+	return forksByBlock, forksByTime
 }

--- a/core/state/statedb.go
+++ b/core/state/statedb.go
@@ -1216,7 +1216,7 @@ func (s *StateDB) commit(deleteEmptyObjects bool, noStorageWiping bool, blockNum
 		return nil, fmt.Errorf("commit aborted due to earlier error: %v", s.dbErr)
 	}
 	// Finalize any pending changes and merge everything into the tries
-	s.IntermediateRoot(false) // TODO double check this is necessary
+	s.IntermediateRoot(deleteEmptyObjects)
 
 	// Short circuit if any error occurs within the IntermediateRoot.
 	if s.dbErr != nil {

--- a/core/state/statedb_test.go
+++ b/core/state/statedb_test.go
@@ -36,6 +36,7 @@ import (
 	"github.com/ethereum/go-ethereum/core/tracing"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/crypto"
+	"github.com/ethereum/go-ethereum/params"
 	"github.com/ethereum/go-ethereum/rlp"
 	"github.com/ethereum/go-ethereum/trie"
 	"github.com/ethereum/go-ethereum/trie/trienode"
@@ -1367,4 +1368,48 @@ func TestStorageDirtiness(t *testing.T) {
 	// the storage change is reverted, dirty value should be set back
 	state.RevertToSnapshot(snap)
 	checkDirty(common.Hash{0x1}, common.Hash{0x1}, true)
+}
+
+// TestSystemAddressPreservedOnCommit verifies that the SystemAddress is not
+// deleted when committing with deleteEmptyObjects=true, even though it is
+// empty. Regular empty accounts should still be deleted. This is required for
+// Gnosis AuRa consensus which uses the SystemAddress for system calls.
+func TestSystemAddressPreservedOnCommit(t *testing.T) {
+	db := NewDatabaseForTesting()
+	state, _ := New(types.EmptyRootHash, db)
+
+	regularAddr := common.HexToAddress("0x1234567890123456789012345678901234567890")
+
+	// Touch both accounts so they exist in state as empty objects.
+	state.CreateAccount(regularAddr)
+	state.CreateAccount(params.SystemAddress)
+
+	// Sanity: both should exist before commit.
+	if !state.Exist(regularAddr) {
+		t.Fatal("regular account should exist before commit")
+	}
+	if !state.Exist(params.SystemAddress) {
+		t.Fatal("SystemAddress should exist before commit")
+	}
+
+	// Commit with deleteEmptyObjects = true.
+	root, err := state.Commit(0, true, false)
+	if err != nil {
+		t.Fatalf("commit failed: %v", err)
+	}
+
+	// Reload state from the committed root.
+	state, err = New(root, db)
+	if err != nil {
+		t.Fatalf("failed to reopen state: %v", err)
+	}
+
+	// Regular empty account must be gone.
+	if state.Exist(regularAddr) {
+		t.Fatal("empty regular account should have been deleted")
+	}
+	// SystemAddress must survive.
+	if !state.Exist(params.SystemAddress) {
+		t.Fatal("SystemAddress should NOT be deleted even when empty")
+	}
 }

--- a/core/state_transition.go
+++ b/core/state_transition.go
@@ -388,7 +388,7 @@ func (st *stateTransition) preCheck() error {
 		if len(msg.BlobHashes) == 0 {
 			return ErrMissingBlobHashes
 		}
-		if isOsaka && len(msg.BlobHashes) > params.BlobTxMaxBlobs {
+		if isOsaka && len(msg.BlobHashes) > st.evm.ChainConfig().BlobScheduleConfig.GetMaxBlobsPerTransaction() {
 			return ErrTooManyBlobs
 		}
 		for i, hash := range msg.BlobHashes {

--- a/core/state_transition.go
+++ b/core/state_transition.go
@@ -388,7 +388,7 @@ func (st *stateTransition) preCheck() error {
 		if len(msg.BlobHashes) == 0 {
 			return ErrMissingBlobHashes
 		}
-		if isOsaka && len(msg.BlobHashes) > st.evm.ChainConfig().BlobScheduleConfig.GetMaxBlobsPerTransaction() {
+		if isOsaka && len(msg.BlobHashes) > st.evm.ChainConfig().GetMaxBlobsPerTransaction() {
 			return ErrTooManyBlobs
 		}
 		for i, hash := range msg.BlobHashes {

--- a/core/txpool/blobpool/blobpool.go
+++ b/core/txpool/blobpool/blobpool.go
@@ -446,7 +446,7 @@ func (p *BlobPool) Init(gasTip uint64, head *types.Header, reserver txpool.Reser
 	p.state = state
 
 	// Create new slotter for pre-Osaka blob configuration.
-	slotter := newSlotter(p.chain.Config().BlobScheduleConfig.GetMaxBlobsPerTransaction())
+	slotter := newSlotter(p.chain.Config().GetMaxBlobsPerTransaction())
 
 	// See if we need to migrate the queue blob store after fusaka
 	slotter, err = tryMigrate(p.chain.Config(), slotter, queuedir)
@@ -484,7 +484,7 @@ func (p *BlobPool) Init(gasTip uint64, head *types.Header, reserver txpool.Reser
 	}
 	var (
 		basefee = uint256.MustFromBig(eip1559.CalcBaseFee(p.chain.Config(), head))
-		blobfee = uint256.NewInt(uint64(p.chain.Config().BlobScheduleConfig.GetMinBlobGasPrice()))
+		blobfee = uint256.NewInt(p.chain.Config().GetMinBlobGasPrice())
 	)
 	if head.ExcessBlobGas != nil {
 		blobfee = uint256.MustFromBig(eip4844.CalcBlobFee(p.chain.Config(), head))
@@ -922,7 +922,7 @@ func (p *BlobPool) Reset(oldHead, newHead *types.Header) {
 	// Reset the price heap for the new set of basefee/blobfee pairs
 	var (
 		basefee = uint256.MustFromBig(eip1559.CalcBaseFee(p.chain.Config(), newHead))
-		blobfee = uint256.NewInt(uint64(p.chain.Config().BlobScheduleConfig.GetMinBlobGasPrice()))
+		blobfee = uint256.NewInt(p.chain.Config().GetMinBlobGasPrice())
 	)
 	if newHead.ExcessBlobGas != nil {
 		blobfee = uint256.MustFromBig(eip4844.CalcBlobFee(p.chain.Config(), newHead))
@@ -1232,7 +1232,7 @@ func (p *BlobPool) ValidateTxBasics(tx *types.Transaction) error {
 		Accept:       1 << types.BlobTxType,
 		MaxSize:      txMaxSize,
 		MinTip:       p.gasTip.Load().ToBig(),
-		MaxBlobCount: p.chain.Config().BlobScheduleConfig.GetMaxBlobsPerTransaction(),
+		MaxBlobCount: p.chain.Config().GetMaxBlobsPerTransaction(),
 	}
 	return txpool.ValidateTransaction(tx, p.head.Load(), p.signer, opts)
 }
@@ -2179,7 +2179,7 @@ func (p *BlobPool) Clear() {
 
 	var (
 		basefee = uint256.MustFromBig(eip1559.CalcBaseFee(p.chain.Config(), p.head.Load()))
-		blobfee = uint256.NewInt(uint64(p.chain.Config().BlobScheduleConfig.GetMinBlobGasPrice()))
+		blobfee = uint256.NewInt(p.chain.Config().GetMinBlobGasPrice())
 	)
 	p.evict = newPriceHeap(basefee, blobfee, p.index)
 }

--- a/core/txpool/blobpool/blobpool.go
+++ b/core/txpool/blobpool/blobpool.go
@@ -69,12 +69,6 @@ const (
 	// never hurt, which is aligned with maxBlobsPerTx constraint enforced internally.
 	txMaxSize = 1024 * 1024
 
-	// maxBlobsPerTx is the maximum number of blobs that a single transaction can
-	// carry. We choose a smaller limit than the protocol-permitted MaxBlobsPerBlock
-	// in order to ensure network and txpool stability.
-	// Note: if you increase this, validation will fail on txMaxSize.
-	maxBlobsPerTx = params.BlobTxMaxBlobs
-
 	// maxTxsPerAccount is the maximum number of blob transactions admitted from
 	// a single account. The limit is enforced to minimize the DoS potential of
 	// a private tx cancelling publicly propagated blobs.

--- a/core/txpool/blobpool/blobpool.go
+++ b/core/txpool/blobpool/blobpool.go
@@ -452,7 +452,7 @@ func (p *BlobPool) Init(gasTip uint64, head *types.Header, reserver txpool.Reser
 	p.state = state
 
 	// Create new slotter for pre-Osaka blob configuration.
-	slotter := newSlotter(params.BlobTxMaxBlobs)
+	slotter := newSlotter(p.chain.Config().BlobScheduleConfig.GetMaxBlobsPerTransaction())
 
 	// See if we need to migrate the queue blob store after fusaka
 	slotter, err = tryMigrate(p.chain.Config(), slotter, queuedir)
@@ -490,7 +490,7 @@ func (p *BlobPool) Init(gasTip uint64, head *types.Header, reserver txpool.Reser
 	}
 	var (
 		basefee = uint256.MustFromBig(eip1559.CalcBaseFee(p.chain.Config(), head))
-		blobfee = uint256.NewInt(params.BlobTxMinBlobGasprice)
+		blobfee = uint256.NewInt(uint64(p.chain.Config().BlobScheduleConfig.GetMinBlobGasPrice()))
 	)
 	if head.ExcessBlobGas != nil {
 		blobfee = uint256.MustFromBig(eip4844.CalcBlobFee(p.chain.Config(), head))
@@ -928,7 +928,7 @@ func (p *BlobPool) Reset(oldHead, newHead *types.Header) {
 	// Reset the price heap for the new set of basefee/blobfee pairs
 	var (
 		basefee = uint256.MustFromBig(eip1559.CalcBaseFee(p.chain.Config(), newHead))
-		blobfee = uint256.MustFromBig(big.NewInt(params.BlobTxMinBlobGasprice))
+		blobfee = uint256.NewInt(uint64(p.chain.Config().BlobScheduleConfig.GetMinBlobGasPrice()))
 	)
 	if newHead.ExcessBlobGas != nil {
 		blobfee = uint256.MustFromBig(eip4844.CalcBlobFee(p.chain.Config(), newHead))
@@ -1238,7 +1238,7 @@ func (p *BlobPool) ValidateTxBasics(tx *types.Transaction) error {
 		Accept:       1 << types.BlobTxType,
 		MaxSize:      txMaxSize,
 		MinTip:       p.gasTip.Load().ToBig(),
-		MaxBlobCount: maxBlobsPerTx,
+		MaxBlobCount: p.chain.Config().BlobScheduleConfig.GetMaxBlobsPerTransaction(),
 	}
 	return txpool.ValidateTransaction(tx, p.head.Load(), p.signer, opts)
 }
@@ -2185,7 +2185,7 @@ func (p *BlobPool) Clear() {
 
 	var (
 		basefee = uint256.MustFromBig(eip1559.CalcBaseFee(p.chain.Config(), p.head.Load()))
-		blobfee = uint256.NewInt(params.BlobTxMinBlobGasprice)
+		blobfee = uint256.NewInt(uint64(p.chain.Config().BlobScheduleConfig.GetMinBlobGasPrice()))
 	)
 	p.evict = newPriceHeap(basefee, blobfee, p.index)
 }

--- a/core/txpool/blobpool/blobpool_test.go
+++ b/core/txpool/blobpool/blobpool_test.go
@@ -732,7 +732,7 @@ func TestOpenDrops(t *testing.T) {
 	chain := &testBlockChain{
 		config:  params.MainnetChainConfig,
 		basefee: uint256.NewInt(params.InitialBaseFee),
-		blobfee: uint256.NewInt(params.BlobTxMinBlobGasprice),
+		blobfee: uint256.NewInt(params.DefaultBlobTxMinBlobGasprice),
 		statedb: statedb,
 	}
 	pool := New(Config{Datadir: storage}, chain, nil)
@@ -850,7 +850,7 @@ func TestOpenIndex(t *testing.T) {
 	chain := &testBlockChain{
 		config:  params.MainnetChainConfig,
 		basefee: uint256.NewInt(params.InitialBaseFee),
-		blobfee: uint256.NewInt(params.BlobTxMinBlobGasprice),
+		blobfee: uint256.NewInt(params.DefaultBlobTxMinBlobGasprice),
 		statedb: statedb,
 	}
 	pool := New(Config{Datadir: storage}, chain, nil)
@@ -1691,7 +1691,7 @@ func TestAdd(t *testing.T) {
 				},
 				{ // Same as above but blob fee cap equals minimum, should be accepted
 					from: "alice",
-					tx:   makeUnsignedTx(0, 1, 1, params.BlobTxMinBlobGasprice),
+					tx:   makeUnsignedTx(0, 1, 1, params.DefaultBlobTxMinBlobGasprice),
 					err:  nil,
 				},
 			},
@@ -1832,7 +1832,7 @@ func TestGetBlobs(t *testing.T) {
 	storage := t.TempDir()
 
 	os.MkdirAll(filepath.Join(storage, pendingTransactionStore), 0700)
-	store, _ := billy.Open(billy.Options{Path: filepath.Join(storage, pendingTransactionStore)}, newSlotter(params.BlobTxMaxBlobs), nil)
+	store, _ := billy.Open(billy.Options{Path: filepath.Join(storage, pendingTransactionStore)}, newSlotter(params.DefaultBlobTxMaxBlobs), nil)
 
 	// Create transactions from a few accounts.
 	var (

--- a/core/txpool/blobpool/limbo.go
+++ b/core/txpool/blobpool/limbo.go
@@ -56,7 +56,7 @@ func newLimbo(config *params.ChainConfig, datadir string) (*limbo, error) {
 	}
 
 	// Create new slotter for pre-Osaka blob configuration.
-	slotter := newSlotter(config.BlobScheduleConfig.GetMaxBlobsPerTransaction())
+	slotter := newSlotter(config.GetMaxBlobsPerTransaction())
 
 	// See if we need to migrate the limbo after fusaka.
 	slotter, err := tryMigrate(config, slotter, datadir)

--- a/core/txpool/blobpool/limbo.go
+++ b/core/txpool/blobpool/limbo.go
@@ -56,7 +56,7 @@ func newLimbo(config *params.ChainConfig, datadir string) (*limbo, error) {
 	}
 
 	// Create new slotter for pre-Osaka blob configuration.
-	slotter := newSlotter(params.BlobTxMaxBlobs)
+	slotter := newSlotter(config.BlobScheduleConfig.GetMaxBlobsPerTransaction())
 
 	// See if we need to migrate the limbo after fusaka.
 	slotter, err := tryMigrate(config, slotter, datadir)

--- a/core/txpool/blobpool/slotter.go
+++ b/core/txpool/blobpool/slotter.go
@@ -41,7 +41,7 @@ func tryMigrate(config *params.ChainConfig, slotter billy.SlotSizeFn, datadir st
 		// If the version found is less than the currently configured store version,
 		// perform a migration then write the updated version of the store.
 		if version < storeVersion {
-			newSlotter := newSlotterEIP7594(config.BlobScheduleConfig.GetMaxBlobsPerTransaction())
+			newSlotter := newSlotterEIP7594(config.GetMaxBlobsPerTransaction())
 			if err := billy.Migrate(billy.Options{Path: datadir, Repair: true}, slotter, newSlotter); err != nil {
 				return nil, err
 			}
@@ -53,7 +53,7 @@ func tryMigrate(config *params.ChainConfig, slotter billy.SlotSizeFn, datadir st
 			store.Close()
 		}
 		// Set the slotter to the format now that the Osaka is active.
-		slotter = newSlotterEIP7594(config.BlobScheduleConfig.GetMaxBlobsPerTransaction())
+		slotter = newSlotterEIP7594(config.GetMaxBlobsPerTransaction())
 	}
 	return slotter, nil
 }

--- a/core/txpool/blobpool/slotter.go
+++ b/core/txpool/blobpool/slotter.go
@@ -41,7 +41,7 @@ func tryMigrate(config *params.ChainConfig, slotter billy.SlotSizeFn, datadir st
 		// If the version found is less than the currently configured store version,
 		// perform a migration then write the updated version of the store.
 		if version < storeVersion {
-			newSlotter := newSlotterEIP7594(params.BlobTxMaxBlobs)
+			newSlotter := newSlotterEIP7594(config.BlobScheduleConfig.GetMaxBlobsPerTransaction())
 			if err := billy.Migrate(billy.Options{Path: datadir, Repair: true}, slotter, newSlotter); err != nil {
 				return nil, err
 			}
@@ -53,7 +53,7 @@ func tryMigrate(config *params.ChainConfig, slotter billy.SlotSizeFn, datadir st
 			store.Close()
 		}
 		// Set the slotter to the format now that the Osaka is active.
-		slotter = newSlotterEIP7594(params.BlobTxMaxBlobs)
+		slotter = newSlotterEIP7594(config.BlobScheduleConfig.GetMaxBlobsPerTransaction())
 	}
 	return slotter, nil
 }

--- a/core/txpool/validation.go
+++ b/core/txpool/validation.go
@@ -31,7 +31,6 @@ import (
 	"github.com/ethereum/go-ethereum/params"
 )
 
-
 // ValidationOptions define certain differences between transaction validation
 // across the different pools without having to duplicate those checks.
 type ValidationOptions struct {

--- a/core/txpool/validation.go
+++ b/core/txpool/validation.go
@@ -31,11 +31,6 @@ import (
 	"github.com/ethereum/go-ethereum/params"
 )
 
-var (
-	// blobTxMinBlobGasPrice is the big.Int version of the configured protocol
-	// parameter to avoid constructing a new big integer for every transaction.
-	blobTxMinBlobGasPrice = big.NewInt(params.BlobTxMinBlobGasprice)
-)
 
 // ValidationOptions define certain differences between transaction validation
 // across the different pools without having to duplicate those checks.
@@ -173,8 +168,9 @@ func validateBlobTx(tx *types.Transaction, head *types.Header, opts *ValidationO
 		return fmt.Errorf("unexpected sidecar version, want: %d, got: %d", version, sidecar.Version)
 	}
 	// Ensure the blob fee cap satisfies the minimum blob gas price
-	if tx.BlobGasFeeCapIntCmp(blobTxMinBlobGasPrice) < 0 {
-		return fmt.Errorf("%w: blob fee cap %v, minimum needed %v", ErrTxGasPriceTooLow, tx.BlobGasFeeCap(), blobTxMinBlobGasPrice)
+	minBlobGasPrice := big.NewInt(opts.Config.BlobScheduleConfig.GetMinBlobGasPrice())
+	if tx.BlobGasFeeCapIntCmp(minBlobGasPrice) < 0 {
+		return fmt.Errorf("%w: blob fee cap %v, minimum needed %v", ErrTxGasPriceTooLow, tx.BlobGasFeeCap(), minBlobGasPrice)
 	}
 	// Ensure the number of items in the blob transaction and various side
 	// data match up before doing any expensive validations
@@ -182,8 +178,9 @@ func validateBlobTx(tx *types.Transaction, head *types.Header, opts *ValidationO
 	if len(hashes) == 0 {
 		return errors.New("blobless blob transaction")
 	}
-	if len(hashes) > params.BlobTxMaxBlobs {
-		return fmt.Errorf("too many blobs in transaction: have %d, permitted %d", len(hashes), params.BlobTxMaxBlobs)
+	maxBlobs := opts.Config.BlobScheduleConfig.GetMaxBlobsPerTransaction()
+	if len(hashes) > maxBlobs {
+		return fmt.Errorf("too many blobs in transaction: have %d, permitted %d", len(hashes), maxBlobs)
 	}
 	if len(sidecar.Blobs) != len(hashes) {
 		return fmt.Errorf("invalid number of %d blobs compared to %d blob hashes", len(sidecar.Blobs), len(hashes))

--- a/core/txpool/validation.go
+++ b/core/txpool/validation.go
@@ -167,7 +167,7 @@ func validateBlobTx(tx *types.Transaction, head *types.Header, opts *ValidationO
 		return fmt.Errorf("unexpected sidecar version, want: %d, got: %d", version, sidecar.Version)
 	}
 	// Ensure the blob fee cap satisfies the minimum blob gas price
-	minBlobGasPrice := big.NewInt(opts.Config.BlobScheduleConfig.GetMinBlobGasPrice())
+	minBlobGasPrice := new(big.Int).SetUint64(opts.Config.GetMinBlobGasPrice())
 	if tx.BlobGasFeeCapIntCmp(minBlobGasPrice) < 0 {
 		return fmt.Errorf("%w: blob fee cap %v, minimum needed %v", ErrTxGasPriceTooLow, tx.BlobGasFeeCap(), minBlobGasPrice)
 	}
@@ -177,7 +177,7 @@ func validateBlobTx(tx *types.Transaction, head *types.Header, opts *ValidationO
 	if len(hashes) == 0 {
 		return errors.New("blobless blob transaction")
 	}
-	maxBlobs := opts.Config.BlobScheduleConfig.GetMaxBlobsPerTransaction()
+	maxBlobs := opts.Config.GetMaxBlobsPerTransaction()
 	if len(hashes) > maxBlobs {
 		return fmt.Errorf("too many blobs in transaction: have %d, permitted %d", len(hashes), maxBlobs)
 	}

--- a/core/txpool/validation_test.go
+++ b/core/txpool/validation_test.go
@@ -52,10 +52,13 @@ func gnosisTestConfig() *params.ChainConfig {
 		CancunTime:              newUint64(0),
 		TerminalTotalDifficulty: big.NewInt(0),
 		BlobScheduleConfig:      params.GnosisBlobSchedule,
+		MinBlobGasPrice:         newUint64(params.GnosisBlobTxMinBlobGasprice),
+		MaxBlobsPerTransaction:  newInt(params.GnosisBlobTxMaxBlobs),
 	}
 }
 
 func newUint64(n uint64) *uint64 { return &n }
+func newInt(n int) *int          { return &n }
 
 func TestValidateTransactionEIP2681(t *testing.T) {
 	key, err := crypto.GenerateKey()

--- a/core/txpool/validation_test.go
+++ b/core/txpool/validation_test.go
@@ -18,17 +18,44 @@ package txpool
 
 import (
 	"crypto/ecdsa"
+	"crypto/sha256"
 	"errors"
 	"math"
 	"math/big"
+	"strings"
 	"testing"
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/crypto"
+	"github.com/ethereum/go-ethereum/crypto/kzg4844"
 	"github.com/ethereum/go-ethereum/params"
+	"github.com/holiman/uint256"
 )
+
+// gnosisTestConfig returns a chain config with Cancun enabled and Gnosis blob parameters.
+func gnosisTestConfig() *params.ChainConfig {
+	return &params.ChainConfig{
+		ChainID:                 big.NewInt(100),
+		HomesteadBlock:          big.NewInt(0),
+		EIP150Block:             big.NewInt(0),
+		EIP155Block:             big.NewInt(0),
+		EIP158Block:             big.NewInt(0),
+		ByzantiumBlock:          big.NewInt(0),
+		ConstantinopleBlock:     big.NewInt(0),
+		PetersburgBlock:         big.NewInt(0),
+		IstanbulBlock:           big.NewInt(0),
+		BerlinBlock:             big.NewInt(0),
+		LondonBlock:             big.NewInt(0),
+		ShanghaiTime:            newUint64(0),
+		CancunTime:              newUint64(0),
+		TerminalTotalDifficulty: big.NewInt(0),
+		BlobScheduleConfig:      params.GnosisBlobSchedule,
+	}
+}
+
+func newUint64(n uint64) *uint64 { return &n }
 
 func TestValidateTransactionEIP2681(t *testing.T) {
 	key, err := crypto.GenerateKey()
@@ -94,6 +121,106 @@ func TestValidateTransactionEIP2681(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestValidateBlobTxGnosisParams(t *testing.T) {
+	key, err := crypto.GenerateKey()
+	if err != nil {
+		t.Fatal(err)
+	}
+	gnosisConfig := gnosisTestConfig()
+	head := &types.Header{
+		Number:     big.NewInt(1),
+		GasLimit:   30000000,
+		Time:       1,
+		Difficulty: big.NewInt(0),
+	}
+	signer := types.LatestSigner(gnosisConfig)
+
+	tests := []struct {
+		name       string
+		blobCount  int
+		blobFeeCap uint64
+		wantErr    string
+	}{
+		{
+			name:       "gnosis: 2 blobs with sufficient fee accepted",
+			blobCount:  2,
+			blobFeeCap: 1000000000,
+			wantErr:    "",
+		},
+		{
+			name:       "gnosis: 3 blobs rejected",
+			blobCount:  3,
+			blobFeeCap: 1000000000,
+			wantErr:    "too many blobs in transaction: have 3, permitted 2",
+		},
+		{
+			name:       "gnosis: fee cap below minimum rejected",
+			blobCount:  1,
+			blobFeeCap: 999999999,
+			wantErr:    "blob fee cap",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tx := createBlobTx(key, gnosisConfig, tt.blobCount, tt.blobFeeCap)
+			opts := &ValidationOptions{
+				Config:       gnosisConfig,
+				Accept:       1 << types.BlobTxType,
+				MaxSize:      1024 * 1024,
+				MaxBlobCount: 6, // pool-level limit; chain-level limit is stricter
+				MinTip:       big.NewInt(0),
+			}
+			err := ValidateTransaction(tx, head, signer, opts)
+			if tt.wantErr == "" {
+				if err != nil {
+					t.Fatalf("unexpected error: %v", err)
+				}
+			} else {
+				if err == nil {
+					t.Fatalf("expected error containing %q, got nil", tt.wantErr)
+				}
+				if !strings.Contains(err.Error(), tt.wantErr) {
+					t.Fatalf("error %q does not contain %q", err.Error(), tt.wantErr)
+				}
+			}
+		})
+	}
+}
+
+// createBlobTx creates a blob transaction with the given number of blobs and fee cap.
+func createBlobTx(key *ecdsa.PrivateKey, config *params.ChainConfig, blobCount int, blobFeeCap uint64) *types.Transaction {
+	var (
+		blobs       []kzg4844.Blob
+		commitments []kzg4844.Commitment
+		proofs      []kzg4844.Proof
+		hashes      []common.Hash
+	)
+	for i := 0; i < blobCount; i++ {
+		var blob kzg4844.Blob
+		blob[0] = byte(i + 1) // non-zero so each blob is unique
+		commit, _ := kzg4844.BlobToCommitment(&blob)
+		proof, _ := kzg4844.ComputeBlobProof(&blob, commit)
+		blobs = append(blobs, blob)
+		commitments = append(commitments, commit)
+		proofs = append(proofs, proof)
+		hashes = append(hashes, kzg4844.CalcBlobHashV1(sha256.New(), &commit))
+	}
+	sidecar := types.NewBlobTxSidecar(types.BlobSidecarVersion0, blobs, commitments, proofs)
+	blobtx := &types.BlobTx{
+		ChainID:    uint256.MustFromBig(config.ChainID),
+		Nonce:      0,
+		GasTipCap:  uint256.NewInt(1),
+		GasFeeCap:  uint256.NewInt(1000000000),
+		Gas:        21000,
+		BlobFeeCap: uint256.NewInt(blobFeeCap),
+		BlobHashes: hashes,
+		Value:      uint256.NewInt(0),
+		Sidecar:    sidecar,
+	}
+	return types.MustSignNewTx(key, types.LatestSigner(config), blobtx)
 }
 
 // createTestTransaction creates a basic transaction for testing

--- a/core/vm/runtime/runtime.go
+++ b/core/vm/runtime/runtime.go
@@ -107,11 +107,7 @@ func setDefaults(cfg *Config) {
 		cfg.BaseFee = big.NewInt(params.InitialBaseFee)
 	}
 	if cfg.BlobBaseFee == nil {
-		if cfg.ChainConfig != nil && cfg.ChainConfig.BlobScheduleConfig != nil {
-			cfg.BlobBaseFee = big.NewInt(cfg.ChainConfig.BlobScheduleConfig.GetMinBlobGasPrice())
-		} else {
-			cfg.BlobBaseFee = big.NewInt(params.DefaultBlobTxMinBlobGasprice)
-		}
+		cfg.BlobBaseFee = new(big.Int).SetUint64(cfg.ChainConfig.GetMinBlobGasPrice())
 	}
 	cfg.Random = &(common.Hash{})
 }

--- a/core/vm/runtime/runtime.go
+++ b/core/vm/runtime/runtime.go
@@ -110,7 +110,7 @@ func setDefaults(cfg *Config) {
 		if cfg.ChainConfig != nil && cfg.ChainConfig.BlobScheduleConfig != nil {
 			cfg.BlobBaseFee = big.NewInt(cfg.ChainConfig.BlobScheduleConfig.GetMinBlobGasPrice())
 		} else {
-			cfg.BlobBaseFee = big.NewInt(params.BlobTxMinBlobGasprice)
+			cfg.BlobBaseFee = big.NewInt(params.DefaultBlobTxMinBlobGasprice)
 		}
 	}
 	cfg.Random = &(common.Hash{})

--- a/core/vm/runtime/runtime.go
+++ b/core/vm/runtime/runtime.go
@@ -107,7 +107,11 @@ func setDefaults(cfg *Config) {
 		cfg.BaseFee = big.NewInt(params.InitialBaseFee)
 	}
 	if cfg.BlobBaseFee == nil {
-		cfg.BlobBaseFee = big.NewInt(params.BlobTxMinBlobGasprice)
+		if cfg.ChainConfig != nil && cfg.ChainConfig.BlobScheduleConfig != nil {
+			cfg.BlobBaseFee = big.NewInt(cfg.ChainConfig.BlobScheduleConfig.GetMinBlobGasPrice())
+		} else {
+			cfg.BlobBaseFee = big.NewInt(params.BlobTxMinBlobGasprice)
+		}
 	}
 	cfg.Random = &(common.Hash{})
 }

--- a/internal/ethapi/transaction_args.go
+++ b/internal/ethapi/transaction_args.go
@@ -126,7 +126,7 @@ func (args *TransactionArgs) setDefaults(ctx context.Context, b Backend, config 
 	if args.BlobHashes != nil && len(args.BlobHashes) == 0 {
 		return errors.New("need at least 1 blob for a blob transaction")
 	}
-	maxBlobs := b.ChainConfig().BlobScheduleConfig.GetMaxBlobsPerTransaction()
+	maxBlobs := b.ChainConfig().GetMaxBlobsPerTransaction()
 	if args.BlobHashes != nil && len(args.BlobHashes) > maxBlobs {
 		return fmt.Errorf("too many blobs in transaction (have=%d, max=%d)", len(args.BlobHashes), maxBlobs)
 	}

--- a/internal/ethapi/transaction_args.go
+++ b/internal/ethapi/transaction_args.go
@@ -126,8 +126,9 @@ func (args *TransactionArgs) setDefaults(ctx context.Context, b Backend, config 
 	if args.BlobHashes != nil && len(args.BlobHashes) == 0 {
 		return errors.New("need at least 1 blob for a blob transaction")
 	}
-	if args.BlobHashes != nil && len(args.BlobHashes) > params.BlobTxMaxBlobs {
-		return fmt.Errorf("too many blobs in transaction (have=%d, max=%d)", len(args.BlobHashes), params.BlobTxMaxBlobs)
+	maxBlobs := b.ChainConfig().BlobScheduleConfig.GetMaxBlobsPerTransaction()
+	if args.BlobHashes != nil && len(args.BlobHashes) > maxBlobs {
+		return fmt.Errorf("too many blobs in transaction (have=%d, max=%d)", len(args.BlobHashes), maxBlobs)
 	}
 
 	// create check

--- a/params/chainspecs/chiado.json
+++ b/params/chainspecs/chiado.json
@@ -17,7 +17,6 @@
   "cancunTime": 1706724940,
   "pragueTime": 1741254220,
   "osakaTime": 1773653580,
-  "minBlobGasPrice": 1000000000,
   "blobSchedule": {
     "cancun": {
       "target": 1,
@@ -33,7 +32,9 @@
       "target": 1,
       "max": 2,
       "baseFeeUpdateFraction": 1112826
-    }
+    },
+    "minBlobGasPrice": 1000000000,
+    "maxBlobsPerTransaction": 2
   },
   "noPruneContracts": {
     "0xb97036A26259B7147018913bD58a774cf91acf25": true

--- a/params/chainspecs/chiado.json
+++ b/params/chainspecs/chiado.json
@@ -32,10 +32,10 @@
       "target": 1,
       "max": 2,
       "baseFeeUpdateFraction": 1112826
-    },
-    "minBlobGasPrice": 1000000000,
-    "maxBlobsPerTransaction": 2
+    }
   },
+  "minBlobGasPrice": 1000000000,
+  "maxBlobsPerTransaction": 2,
   "noPruneContracts": {
     "0xb97036A26259B7147018913bD58a774cf91acf25": true
   },

--- a/params/chainspecs/gnosis.json
+++ b/params/chainspecs/gnosis.json
@@ -39,10 +39,10 @@
       "target": 1,
       "max": 2,
       "baseFeeUpdateFraction": 1112826
-    },
-    "minBlobGasPrice": 1000000000,
-    "maxBlobsPerTransaction": 2
+    }
   },
+  "minBlobGasPrice": 1000000000,
+  "maxBlobsPerTransaction": 2,
   "depositContractAddress": "0x0B98057eA310F4d31F2a452B414647007d1645d9",
   "aura": {
     "stepDuration": 5,

--- a/params/chainspecs/gnosis.json
+++ b/params/chainspecs/gnosis.json
@@ -39,7 +39,9 @@
       "target": 1,
       "max": 2,
       "baseFeeUpdateFraction": 1112826
-    }
+    },
+    "minBlobGasPrice": 1000000000,
+    "maxBlobsPerTransaction": 2
   },
   "depositContractAddress": "0x0B98057eA310F4d31F2a452B414647007d1645d9",
   "aura": {

--- a/params/config.go
+++ b/params/config.go
@@ -370,21 +370,21 @@ var (
 var (
 	// DefaultCancunBlobConfig is the default blob configuration for the Cancun fork.
 	DefaultCancunBlobConfig = &BlobConfig{
-		Target:         1,
-		Max:            2,
-		UpdateFraction: 1112826,
+		Target:         3,
+		Max:            6,
+		UpdateFraction: 3338477,
 	}
 	// DefaultPragueBlobConfig is the default blob configuration for the Prague fork.
 	DefaultPragueBlobConfig = &BlobConfig{
-		Target:         1,
-		Max:            2,
-		UpdateFraction: 1112826,
+		Target:         6,
+		Max:            9,
+		UpdateFraction: 5007716,
 	}
 	// DefaultOsakaBlobConfig is the default blob configuration for the Osaka fork.
 	DefaultOsakaBlobConfig = &BlobConfig{
-		Target:         1,
-		Max:            2,
-		UpdateFraction: 1112826,
+		Target:         6,
+		Max:            9,
+		UpdateFraction: 5007716,
 	}
 	// DefaultBPO1BlobConfig is the default blob configuration for the BPO1 fork.
 	DefaultBPO1BlobConfig = &BlobConfig{

--- a/params/config.go
+++ b/params/config.go
@@ -35,7 +35,6 @@ var (
 )
 
 func newUint64(val uint64) *uint64 { return &val }
-func newInt(val int) *int          { return &val }
 
 var (
 	MainnetTerminalTotalDifficulty, _     = new(big.Int).SetString("58_750_000_000_000_000_000_000", 0)
@@ -438,11 +437,9 @@ var (
 	}
 	// GnosisBlobSchedule is the blob schedule for Gnosis chain.
 	GnosisBlobSchedule = &BlobScheduleConfig{
-		Cancun:                 GnosisCancunBlobConfig,
-		Prague:                 GnosisPragueBlobConfig,
-		Osaka:                  GnosisOsakaBlobConfig,
-		MinBlobGasPrice:        newUint64(GnosisBlobTxMinBlobGasprice),
-		MaxBlobsPerTransaction: newInt(GnosisBlobTxMaxBlobs),
+		Cancun: GnosisCancunBlobConfig,
+		Prague: GnosisPragueBlobConfig,
+		Osaka:  GnosisOsakaBlobConfig,
 	}
 )
 
@@ -522,6 +519,14 @@ type ChainConfig struct {
 	Clique             *CliqueConfig       `json:"clique,omitempty"`
 	BlobScheduleConfig *BlobScheduleConfig `json:"blobSchedule,omitempty"`
 	Aura               *AuRaConfig         `json:"aura,omitempty"`
+
+	// MinBlobGasPrice overrides the default minimum blob gas price for this chain.
+	// If nil, the global default (1 wei) is used.
+	MinBlobGasPrice *uint64 `json:"minBlobGasPrice,omitempty"`
+
+	// MaxBlobsPerTransaction overrides the default max blobs per transaction for this chain.
+	// If nil, the global default (6) is used.
+	MaxBlobsPerTransaction *int `json:"maxBlobsPerTransaction,omitempty"`
 }
 
 // EthashConfig is the consensus engine configs for proof-of-work based sealing.
@@ -764,30 +769,22 @@ type BlobScheduleConfig struct {
 	BPO4      *BlobConfig `json:"bpo4,omitempty"`
 	BPO5      *BlobConfig `json:"bpo5,omitempty"`
 	Amsterdam *BlobConfig `json:"amsterdam,omitempty"`
-
-	// MinBlobGasPrice overrides the global BlobTxMinBlobGasprice for this chain.
-	// If zero/nil, the global default is used.
-	MinBlobGasPrice *uint64 `json:"minBlobGasPrice,omitempty"`
-
-	// MaxBlobsPerTransaction overrides the global BlobTxMaxBlobs for this chain.
-	// If zero/nil, the global default is used.
-	MaxBlobsPerTransaction *int `json:"maxBlobsPerTransaction,omitempty"`
 }
 
 // GetMinBlobGasPrice returns the chain-specific minimum blob gas price,
 // falling back to the global default if not set.
-func (bsc *BlobScheduleConfig) GetMinBlobGasPrice() int64 {
-	if bsc != nil && bsc.MinBlobGasPrice != nil {
-		return int64(*bsc.MinBlobGasPrice)
+func (c *ChainConfig) GetMinBlobGasPrice() uint64 {
+	if c != nil && c.MinBlobGasPrice != nil {
+		return *c.MinBlobGasPrice
 	}
-	return int64(DefaultBlobTxMinBlobGasprice)
+	return DefaultBlobTxMinBlobGasprice
 }
 
 // GetMaxBlobsPerTransaction returns the chain-specific max blobs per tx,
 // falling back to the global default if not set.
-func (bsc *BlobScheduleConfig) GetMaxBlobsPerTransaction() int {
-	if bsc != nil && bsc.MaxBlobsPerTransaction != nil {
-		return *bsc.MaxBlobsPerTransaction
+func (c *ChainConfig) GetMaxBlobsPerTransaction() int {
+	if c != nil && c.MaxBlobsPerTransaction != nil {
+		return *c.MaxBlobsPerTransaction
 	}
 	return DefaultBlobTxMaxBlobs
 }

--- a/params/config.go
+++ b/params/config.go
@@ -35,6 +35,7 @@ var (
 )
 
 func newUint64(val uint64) *uint64 { return &val }
+func newInt(val int) *int          { return &val }
 
 var (
 	MainnetTerminalTotalDifficulty, _     = new(big.Int).SetString("58_750_000_000_000_000_000_000", 0)
@@ -437,9 +438,11 @@ var (
 	}
 	// GnosisBlobSchedule is the blob schedule for Gnosis chain.
 	GnosisBlobSchedule = &BlobScheduleConfig{
-		Cancun: GnosisCancunBlobConfig,
-		Prague: GnosisPragueBlobConfig,
-		Osaka:  GnosisOsakaBlobConfig,
+		Cancun:                 GnosisCancunBlobConfig,
+		Prague:                 GnosisPragueBlobConfig,
+		Osaka:                  GnosisOsakaBlobConfig,
+		MinBlobGasPrice:        newUint64(GnosisBlobTxMinBlobGasprice),
+		MaxBlobsPerTransaction: newInt(GnosisBlobTxMaxBlobs),
 	}
 )
 

--- a/params/config.go
+++ b/params/config.go
@@ -416,6 +416,31 @@ var (
 		Prague: DefaultPragueBlobConfig,
 		Osaka:  DefaultOsakaBlobConfig,
 	}
+
+	// GnosisCancunBlobConfig is the Gnosis blob configuration for the Cancun fork.
+	GnosisCancunBlobConfig = &BlobConfig{
+		Target:         1,
+		Max:            2,
+		UpdateFraction: 1112826,
+	}
+	// GnosisPragueBlobConfig is the Gnosis blob configuration for the Prague fork.
+	GnosisPragueBlobConfig = &BlobConfig{
+		Target:         1,
+		Max:            2,
+		UpdateFraction: 1112826,
+	}
+	// GnosisOsakaBlobConfig is the Gnosis blob configuration for the Osaka fork.
+	GnosisOsakaBlobConfig = &BlobConfig{
+		Target:         1,
+		Max:            2,
+		UpdateFraction: 1112826,
+	}
+	// GnosisBlobSchedule is the blob schedule for Gnosis chain.
+	GnosisBlobSchedule = &BlobScheduleConfig{
+		Cancun: GnosisCancunBlobConfig,
+		Prague: GnosisPragueBlobConfig,
+		Osaka:  GnosisOsakaBlobConfig,
+	}
 )
 
 // NetworkNames are user friendly names to use in the chain spec banner.
@@ -752,7 +777,7 @@ func (bsc *BlobScheduleConfig) GetMinBlobGasPrice() int64 {
 	if bsc != nil && bsc.MinBlobGasPrice != nil {
 		return int64(*bsc.MinBlobGasPrice)
 	}
-	return int64(BlobTxMinBlobGasprice)
+	return int64(DefaultBlobTxMinBlobGasprice)
 }
 
 // GetMaxBlobsPerTransaction returns the chain-specific max blobs per tx,
@@ -761,7 +786,7 @@ func (bsc *BlobScheduleConfig) GetMaxBlobsPerTransaction() int {
 	if bsc != nil && bsc.MaxBlobsPerTransaction != nil {
 		return *bsc.MaxBlobsPerTransaction
 	}
-	return BlobTxMaxBlobs
+	return DefaultBlobTxMaxBlobs
 }
 
 // IsHomestead returns whether num is either equal to the homestead block or greater.

--- a/params/config.go
+++ b/params/config.go
@@ -736,6 +736,32 @@ type BlobScheduleConfig struct {
 	BPO4      *BlobConfig `json:"bpo4,omitempty"`
 	BPO5      *BlobConfig `json:"bpo5,omitempty"`
 	Amsterdam *BlobConfig `json:"amsterdam,omitempty"`
+
+	// MinBlobGasPrice overrides the global BlobTxMinBlobGasprice for this chain.
+	// If zero/nil, the global default is used.
+	MinBlobGasPrice *uint64 `json:"minBlobGasPrice,omitempty"`
+
+	// MaxBlobsPerTransaction overrides the global BlobTxMaxBlobs for this chain.
+	// If zero/nil, the global default is used.
+	MaxBlobsPerTransaction *int `json:"maxBlobsPerTransaction,omitempty"`
+}
+
+// GetMinBlobGasPrice returns the chain-specific minimum blob gas price,
+// falling back to the global default if not set.
+func (bsc *BlobScheduleConfig) GetMinBlobGasPrice() int64 {
+	if bsc != nil && bsc.MinBlobGasPrice != nil {
+		return int64(*bsc.MinBlobGasPrice)
+	}
+	return int64(BlobTxMinBlobGasprice)
+}
+
+// GetMaxBlobsPerTransaction returns the chain-specific max blobs per tx,
+// falling back to the global default if not set.
+func (bsc *BlobScheduleConfig) GetMaxBlobsPerTransaction() int {
+	if bsc != nil && bsc.MaxBlobsPerTransaction != nil {
+		return *bsc.MaxBlobsPerTransaction
+	}
+	return BlobTxMaxBlobs
 }
 
 // IsHomestead returns whether num is either equal to the homestead block or greater.

--- a/params/config_test.go
+++ b/params/config_test.go
@@ -156,60 +156,41 @@ func TestTimestampCompatError(t *testing.T) {
 		"mismatching Shanghai fork timestamp in database (have timestamp 0, want timestamp 1681338455, rewindto timestamp 0)")
 }
 
-func TestBlobScheduleGetters(t *testing.T) {
-	t.Run("nil BlobScheduleConfig returns defaults", func(t *testing.T) {
-		var bsc *BlobScheduleConfig
-		if got := bsc.GetMinBlobGasPrice(); got != int64(DefaultBlobTxMinBlobGasprice) {
+func TestBlobParamGetters(t *testing.T) {
+	t.Run("nil ChainConfig returns defaults", func(t *testing.T) {
+		var cfg *ChainConfig
+		if got := cfg.GetMinBlobGasPrice(); got != DefaultBlobTxMinBlobGasprice {
 			t.Fatalf("GetMinBlobGasPrice() = %d, want %d", got, DefaultBlobTxMinBlobGasprice)
 		}
-		if got := bsc.GetMaxBlobsPerTransaction(); got != DefaultBlobTxMaxBlobs {
+		if got := cfg.GetMaxBlobsPerTransaction(); got != DefaultBlobTxMaxBlobs {
 			t.Fatalf("GetMaxBlobsPerTransaction() = %d, want %d", got, DefaultBlobTxMaxBlobs)
 		}
 	})
 
 	t.Run("no overrides returns defaults", func(t *testing.T) {
-		bsc := &BlobScheduleConfig{
-			Cancun: DefaultCancunBlobConfig,
-		}
-		if got := bsc.GetMinBlobGasPrice(); got != int64(DefaultBlobTxMinBlobGasprice) {
+		cfg := &ChainConfig{}
+		if got := cfg.GetMinBlobGasPrice(); got != DefaultBlobTxMinBlobGasprice {
 			t.Fatalf("GetMinBlobGasPrice() = %d, want %d", got, DefaultBlobTxMinBlobGasprice)
 		}
-		if got := bsc.GetMaxBlobsPerTransaction(); got != DefaultBlobTxMaxBlobs {
+		if got := cfg.GetMaxBlobsPerTransaction(); got != DefaultBlobTxMaxBlobs {
 			t.Fatalf("GetMaxBlobsPerTransaction() = %d, want %d", got, DefaultBlobTxMaxBlobs)
 		}
 	})
 
-	t.Run("gnosis blob schedule var returns chain-specific values", func(t *testing.T) {
-		if got := GnosisBlobSchedule.GetMinBlobGasPrice(); got != 1000000000 {
-			t.Fatalf("GetMinBlobGasPrice() = %d, want 1000000000", got)
-		}
-		if got := GnosisBlobSchedule.GetMaxBlobsPerTransaction(); got != 2 {
-			t.Fatalf("GetMaxBlobsPerTransaction() = %d, want 2", got)
-		}
-	})
-
 	t.Run("gnosis chainspec json loads correct blob params", func(t *testing.T) {
-		bsc := GnosisChainConfig.BlobScheduleConfig
-		if bsc == nil {
-			t.Fatal("GnosisChainConfig.BlobScheduleConfig is nil")
-		}
-		if got := bsc.GetMinBlobGasPrice(); got != GnosisBlobTxMinBlobGasprice {
+		if got := GnosisChainConfig.GetMinBlobGasPrice(); got != GnosisBlobTxMinBlobGasprice {
 			t.Fatalf("GetMinBlobGasPrice() = %d, want %d", got, GnosisBlobTxMinBlobGasprice)
 		}
-		if got := bsc.GetMaxBlobsPerTransaction(); got != GnosisBlobTxMaxBlobs {
+		if got := GnosisChainConfig.GetMaxBlobsPerTransaction(); got != GnosisBlobTxMaxBlobs {
 			t.Fatalf("GetMaxBlobsPerTransaction() = %d, want %d", got, GnosisBlobTxMaxBlobs)
 		}
 	})
 
 	t.Run("chiado chainspec json loads correct blob params", func(t *testing.T) {
-		bsc := ChiadoChainConfig.BlobScheduleConfig
-		if bsc == nil {
-			t.Fatal("ChiadoChainConfig.BlobScheduleConfig is nil")
-		}
-		if got := bsc.GetMinBlobGasPrice(); got != GnosisBlobTxMinBlobGasprice {
+		if got := ChiadoChainConfig.GetMinBlobGasPrice(); got != GnosisBlobTxMinBlobGasprice {
 			t.Fatalf("GetMinBlobGasPrice() = %d, want %d", got, GnosisBlobTxMinBlobGasprice)
 		}
-		if got := bsc.GetMaxBlobsPerTransaction(); got != GnosisBlobTxMaxBlobs {
+		if got := ChiadoChainConfig.GetMaxBlobsPerTransaction(); got != GnosisBlobTxMaxBlobs {
 			t.Fatalf("GetMaxBlobsPerTransaction() = %d, want %d", got, GnosisBlobTxMaxBlobs)
 		}
 	})

--- a/params/config_test.go
+++ b/params/config_test.go
@@ -155,3 +155,62 @@ func TestTimestampCompatError(t *testing.T) {
 	require.Equal(t, newTimestampCompatError(errWhat, newUint64(0), newUint64(1681338455)).Error(),
 		"mismatching Shanghai fork timestamp in database (have timestamp 0, want timestamp 1681338455, rewindto timestamp 0)")
 }
+
+func TestBlobScheduleGetters(t *testing.T) {
+	t.Run("nil BlobScheduleConfig returns defaults", func(t *testing.T) {
+		var bsc *BlobScheduleConfig
+		if got := bsc.GetMinBlobGasPrice(); got != int64(DefaultBlobTxMinBlobGasprice) {
+			t.Fatalf("GetMinBlobGasPrice() = %d, want %d", got, DefaultBlobTxMinBlobGasprice)
+		}
+		if got := bsc.GetMaxBlobsPerTransaction(); got != DefaultBlobTxMaxBlobs {
+			t.Fatalf("GetMaxBlobsPerTransaction() = %d, want %d", got, DefaultBlobTxMaxBlobs)
+		}
+	})
+
+	t.Run("no overrides returns defaults", func(t *testing.T) {
+		bsc := &BlobScheduleConfig{
+			Cancun: DefaultCancunBlobConfig,
+		}
+		if got := bsc.GetMinBlobGasPrice(); got != int64(DefaultBlobTxMinBlobGasprice) {
+			t.Fatalf("GetMinBlobGasPrice() = %d, want %d", got, DefaultBlobTxMinBlobGasprice)
+		}
+		if got := bsc.GetMaxBlobsPerTransaction(); got != DefaultBlobTxMaxBlobs {
+			t.Fatalf("GetMaxBlobsPerTransaction() = %d, want %d", got, DefaultBlobTxMaxBlobs)
+		}
+	})
+
+	t.Run("gnosis blob schedule var returns chain-specific values", func(t *testing.T) {
+		if got := GnosisBlobSchedule.GetMinBlobGasPrice(); got != 1000000000 {
+			t.Fatalf("GetMinBlobGasPrice() = %d, want 1000000000", got)
+		}
+		if got := GnosisBlobSchedule.GetMaxBlobsPerTransaction(); got != 2 {
+			t.Fatalf("GetMaxBlobsPerTransaction() = %d, want 2", got)
+		}
+	})
+
+	t.Run("gnosis chainspec json loads correct blob params", func(t *testing.T) {
+		bsc := GnosisChainConfig.BlobScheduleConfig
+		if bsc == nil {
+			t.Fatal("GnosisChainConfig.BlobScheduleConfig is nil")
+		}
+		if got := bsc.GetMinBlobGasPrice(); got != GnosisBlobTxMinBlobGasprice {
+			t.Fatalf("GetMinBlobGasPrice() = %d, want %d", got, GnosisBlobTxMinBlobGasprice)
+		}
+		if got := bsc.GetMaxBlobsPerTransaction(); got != GnosisBlobTxMaxBlobs {
+			t.Fatalf("GetMaxBlobsPerTransaction() = %d, want %d", got, GnosisBlobTxMaxBlobs)
+		}
+	})
+
+	t.Run("chiado chainspec json loads correct blob params", func(t *testing.T) {
+		bsc := ChiadoChainConfig.BlobScheduleConfig
+		if bsc == nil {
+			t.Fatal("ChiadoChainConfig.BlobScheduleConfig is nil")
+		}
+		if got := bsc.GetMinBlobGasPrice(); got != GnosisBlobTxMinBlobGasprice {
+			t.Fatalf("GetMinBlobGasPrice() = %d, want %d", got, GnosisBlobTxMinBlobGasprice)
+		}
+		if got := bsc.GetMaxBlobsPerTransaction(); got != GnosisBlobTxMaxBlobs {
+			t.Fatalf("GetMaxBlobsPerTransaction() = %d, want %d", got, GnosisBlobTxMaxBlobs)
+		}
+	})
+}

--- a/params/protocol_params.go
+++ b/params/protocol_params.go
@@ -174,12 +174,12 @@ const (
 	RefundQuotient        uint64 = 2
 	RefundQuotientEIP3529 uint64 = 5
 
-	BlobTxBytesPerFieldElement         = 32         // Size in bytes of a field element
-	BlobTxFieldElementsPerBlob         = 4096       // Number of field elements stored in a single data blob
-	BlobTxBlobGasPerBlob               = 1 << 17    // Gas consumption of a single data blob (== blob byte size)
-	BlobTxMinBlobGasprice              = 1 // Minimum gas price for data blobs
-	BlobTxPointEvaluationPrecompileGas = 50000 // Gas price for the point evaluation precompile.
-	BlobTxMaxBlobs                     = 6
+	BlobTxBytesPerFieldElement         = 32      // Size in bytes of a field element
+	BlobTxFieldElementsPerBlob         = 4096    // Number of field elements stored in a single data blob
+	BlobTxBlobGasPerBlob               = 1 << 17 // Gas consumption of a single data blob (== blob byte size)
+	DefaultBlobTxMinBlobGasprice       = 1       // Minimum gas price for data blobs
+	BlobTxPointEvaluationPrecompileGas = 50000   // Gas price for the point evaluation precompile.
+	DefaultBlobTxMaxBlobs              = 6
 	BlobBaseCost                       = 1 << 13 // Base execution gas cost for a blob.
 
 	HistoryServeWindow = 8191 // Number of blocks to serve historical block hashes for, EIP-2935.

--- a/params/protocol_params.go
+++ b/params/protocol_params.go
@@ -182,6 +182,9 @@ const (
 	DefaultBlobTxMaxBlobs              = 6
 	BlobBaseCost                       = 1 << 13 // Base execution gas cost for a blob.
 
+	GnosisBlobTxMinBlobGasprice = 1000000000 // Gnosis minimum gas price for data blobs (1 Gwei)
+	GnosisBlobTxMaxBlobs        = 2          // Gnosis max blobs per transaction
+
 	HistoryServeWindow = 8191 // Number of blocks to serve historical block hashes for, EIP-2935.
 
 	MaxBlockSize = 8_388_608 // maximum size of an RLP-encoded block

--- a/params/protocol_params.go
+++ b/params/protocol_params.go
@@ -177,9 +177,9 @@ const (
 	BlobTxBytesPerFieldElement         = 32         // Size in bytes of a field element
 	BlobTxFieldElementsPerBlob         = 4096       // Number of field elements stored in a single data blob
 	BlobTxBlobGasPerBlob               = 1 << 17    // Gas consumption of a single data blob (== blob byte size)
-	BlobTxMinBlobGasprice              = 1000000000 // Minimum gas price for data blobs
-	BlobTxPointEvaluationPrecompileGas = 50000      // Gas price for the point evaluation precompile.
-	BlobTxMaxBlobs                     = 2
+	BlobTxMinBlobGasprice              = 1 // Minimum gas price for data blobs
+	BlobTxPointEvaluationPrecompileGas = 50000 // Gas price for the point evaluation precompile.
+	BlobTxMaxBlobs                     = 6
 	BlobBaseCost                       = 1 << 13 // Base execution gas cost for a blob.
 
 	HistoryServeWindow = 8191 // Number of blocks to serve historical block hashes for, EIP-2935.


### PR DESCRIPTION
### Gnosis Params

`MinBlobGasPrice` and `MaxBlobGasPerTransaction` are hardcoded constants in this repo that were changed to fit Gnosis-chosen parameters

Many blob tests were failing because the tests written by upstream were expecting Ethereum mainnet parameters for `MinBlobGasPrice` and `MaxBlobGasPerTransaction`

There were two ways to address this. I could either go through all the upstream tests and change their expected values to match Gnosis. This would have created many diffs in the test files and would be an on-going maintenance burden.

Or I could revert the change to the hardcoded constants and instead introduce new fields to the `BlobScheduleConfig`: `MinBlobGasPrice` and `MaxBlobsPerTransaction`. When they are defined, geth uses the values from the config. When they are not, geth uses the default constants (ethereum mainnet parameters). This is enforced through getter functions defined on the BlobScheduleConfig.

I chose to take the latter approach to minimize diffs and make this fork more maintainable

non-test code MUST use the getter functions on `BlobScheduleConfig` to access these parameters. To make sure that this happens, I changed the name of the constants to `DefaultBlobTxMinBlobGasprice` and `DefaultBlobTxMaxBlobs`. If we pull in upstream commits that use the old constant, we will get a build error rather than using ethereum mainnet parameters silently. Maintainers of this fork should correct the build error by using the config getter function to access the correct parameter.

By doing this, we enable Gnosis-specific parameters at runtime while still allowing all of the upstream tests to pass by using the Ethereum mainnet parameters.

### Integration Test Failures

Aside from the blob tests failing, we also had integration test failures because the calculated root hashes did not match the test fixtures.

The root cause of the mismatch was this line: https://github.com/gnosischain/go-ethereum/blob/release-1.17.1-gc/core/state/statedb.go#L1175

This change exists to protect the system address from getting deleted. As hinted in the TODO, this is unnecessary because we already protect it from deletion here: https://github.com/gnosischain/go-ethereum/blob/release-1.17.1-gc/core/state/statedb.go#L764

I've written a test case to prove that the system address still doesn't get deleted even if it is empty when we revert line 1175.

Making this change allowed the integration tests to pass

### TODO

- [x] Write Gnosis config tests
- [ ] ~~Hive tests?~~
- [x] Run live node?