### PR TITLE
consensus, core, internal, miner: rework Aura syscall to avoid race condition

### DIFF
--- a/consensus/aura/aura.go
+++ b/consensus/aura/aura.go
@@ -882,7 +882,7 @@ func (c *AuRa) CalculateRewards(_ *params.ChainConfig, header *types.Header, _ [
 }
 
 // See https://github.com/gnosischain/specs/blob/master/execution/withdrawals.md
-func (c *AuRa) ExecuteSystemWithdrawals(statedb vm.StateDB, evm *vm.EVM, withdrawals []*types.Withdrawal) error {
+func (c *AuRa) ExecuteSystemWithdrawals(evm *vm.EVM, withdrawals []*types.Withdrawal) error {
 	if c.cfg.WithdrawalContractAddress == nil {
 		return nil
 	}

--- a/consensus/aura/aura.go
+++ b/consensus/aura/aura.go
@@ -22,6 +22,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"math"
 	"math/big"
 	"sort"
 	"sync"
@@ -554,8 +555,8 @@ func (c *AuRa) Prepare(chain consensus.ChainHeaderReader, header *types.Header, 
 
 }
 
-func (c *AuRa) ApplyRewards(header *types.Header, state vm.StateDB) error {
-	rewards, err := c.CalculateRewards(nil, header, nil)
+func (c *AuRa) ApplyRewards(header *types.Header, state vm.StateDB, evm *vm.EVM) error {
+	rewards, err := c.CalculateRewards(nil, header, nil, evm)
 	if err != nil {
 		return err
 	}
@@ -566,8 +567,8 @@ func (c *AuRa) ApplyRewards(header *types.Header, state vm.StateDB) error {
 }
 
 // word `signal epoch` == word `pending epoch`
-func (c *AuRa) Finalize(chain consensus.ChainHeaderReader, header *types.Header, state vm.StateDB, body *types.Body, receipts []*types.Receipt) {
-	if err := c.ApplyRewards(header, state); err != nil {
+func (c *AuRa) Finalize(chain consensus.ChainHeaderReader, header *types.Header, state vm.StateDB, body *types.Body, receipts []*types.Receipt, evm *vm.EVM) {
+	if err := c.ApplyRewards(header, state, evm); err != nil {
 		panic(err)
 	}
 
@@ -700,8 +701,8 @@ func allHeadersUntil(chain consensus.ChainHeaderReader, from *types.Header, to c
 }
 
 // FinalizeAndAssemble implements consensus.Engine
-func (c *AuRa) FinalizeAndAssemble(_ context.Context, chain consensus.ChainHeaderReader, header *types.Header, state *state.StateDB, body *types.Body, receipts []*types.Receipt) (*types.Block, error) {
-	c.Finalize(chain, header, state, body, receipts)
+func (c *AuRa) FinalizeAndAssemble(_ context.Context, chain consensus.ChainHeaderReader, header *types.Header, state *state.StateDB, body *types.Body, receipts []*types.Receipt, evm *vm.EVM) (*types.Block, error) {
+	c.Finalize(chain, header, state, body, receipts, evm)
 
 	// Assemble and return the final block for sealing
 	return types.NewBlock(header, body, receipts, trie.NewStackTrie(nil)), nil
@@ -838,7 +839,7 @@ func (c *AuRa) emptySteps(fromStep, toStep uint64, parentHash common.Hash) []Emp
 	return res
 }
 
-func (c *AuRa) CalculateRewards(_ *params.ChainConfig, header *types.Header, _ []*types.Header) ([]consensus.Reward, error) {
+func (c *AuRa) CalculateRewards(_ *params.ChainConfig, header *types.Header, _ []*types.Header, evm *vm.EVM) ([]consensus.Reward, error) {
 	var rewardContractAddress BlockRewardContract
 	var foundContract bool
 	for _, c := range c.cfg.BlockRewardContractTransitions {
@@ -852,7 +853,7 @@ func (c *AuRa) CalculateRewards(_ *params.ChainConfig, header *types.Header, _ [
 		beneficiaries := []common.Address{header.Coinbase}
 		rewardKind := []consensus.RewardKind{consensus.RewardAuthor}
 		var amounts []*big.Int
-		beneficiaries, amounts = callBlockRewardAbi(rewardContractAddress.address, c.Syscall, beneficiaries, rewardKind)
+		beneficiaries, amounts = callBlockRewardAbi(rewardContractAddress.address, evm, beneficiaries, rewardKind)
 		rewards := make([]consensus.Reward, len(amounts))
 		for i, amount := range amounts {
 			rewards[i].Beneficiary = beneficiaries[i]
@@ -881,7 +882,7 @@ func (c *AuRa) CalculateRewards(_ *params.ChainConfig, header *types.Header, _ [
 }
 
 // See https://github.com/gnosischain/specs/blob/master/execution/withdrawals.md
-func (c *AuRa) ExecuteSystemWithdrawals(withdrawals []*types.Withdrawal) error {
+func (c *AuRa) ExecuteSystemWithdrawals(statedb vm.StateDB, evm *vm.EVM, withdrawals []*types.Withdrawal) error {
 	if c.cfg.WithdrawalContractAddress == nil {
 		return nil
 	}
@@ -899,10 +900,7 @@ func (c *AuRa) ExecuteSystemWithdrawals(withdrawals []*types.Withdrawal) error {
 		return err
 	}
 
-	_, err = c.Syscall(*c.cfg.WithdrawalContractAddress, packed)
-	if err != nil {
-		log.Warn("ExecuteSystemWithdrawals", "err", err)
-	}
+	_, _, err = evm.Call(params.SystemAddress, *c.cfg.WithdrawalContractAddress, packed, math.MaxUint64, new(uint256.Int))
 	return err
 }
 

--- a/consensus/aura/contract_abi.go
+++ b/consensus/aura/contract_abi.go
@@ -2,17 +2,20 @@ package aura
 
 import (
 	"bytes"
+	"math"
 	"math/big"
 
 	"github.com/ethereum/go-ethereum/accounts/abi"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/consensus"
 	"github.com/ethereum/go-ethereum/consensus/aura/contracts"
+	"github.com/ethereum/go-ethereum/core/vm"
 	"github.com/ethereum/go-ethereum/crypto"
+	"github.com/ethereum/go-ethereum/params"
 	"github.com/holiman/uint256"
 )
 
-func callBlockRewardAbi(contractAddr common.Address, syscall Syscall, beneficiaries []common.Address, rewardKind []consensus.RewardKind) ([]common.Address, []*big.Int) {
+func callBlockRewardAbi(contractAddr common.Address, evm *vm.EVM, beneficiaries []common.Address, rewardKind []consensus.RewardKind) ([]common.Address, []*big.Int) {
 	castedKind := make([]uint16, len(rewardKind))
 	for i := range rewardKind {
 		castedKind[i] = uint16(rewardKind[i])
@@ -21,7 +24,7 @@ func callBlockRewardAbi(contractAddr common.Address, syscall Syscall, beneficiar
 	if err != nil {
 		panic(err)
 	}
-	out, err := syscall(contractAddr, packed)
+	out, _, err := evm.Call(params.SystemAddress, contractAddr, packed, math.MaxUint64, new(uint256.Int))
 	if err != nil {
 		panic(err)
 	}

--- a/consensus/beacon/consensus.go
+++ b/consensus/beacon/consensus.go
@@ -337,16 +337,16 @@ func (beacon *Beacon) Prepare(chain consensus.ChainHeaderReader, header *types.H
 }
 
 // Finalize implements consensus.Engine and processes withdrawals on top.
-func (beacon *Beacon) Finalize(chain consensus.ChainHeaderReader, header *types.Header, state vm.StateDB, body *types.Body, receipts []*types.Receipt) {
+func (beacon *Beacon) Finalize(chain consensus.ChainHeaderReader, header *types.Header, state vm.StateDB, body *types.Body, receipts []*types.Receipt, evm *vm.EVM) {
 	if !beacon.IsPoSHeader(header) {
-		beacon.ethone.Finalize(chain, header, state, body, receipts)
+		beacon.ethone.Finalize(chain, header, state, body, receipts, evm)
 		return
 	}
 
 	// GNOSIS: if the network has merged and this was an ex-AuRa
 	// network, still call the reward contract.
 	if a, ok := beacon.ethone.(*aura.AuRa); ok {
-		if err := a.ApplyRewards(header, state); err != nil {
+		if err := a.ApplyRewards(header, state, evm); err != nil {
 			panic(fmt.Sprintf("error applying reward %v", err))
 		}
 	}
@@ -354,7 +354,7 @@ func (beacon *Beacon) Finalize(chain consensus.ChainHeaderReader, header *types.
 	// Withdrawals processing.
 	if auraEngine, ok := beacon.ethone.(*aura.AuRa); ok {
 		if body.Withdrawals != nil {
-			if err := auraEngine.ExecuteSystemWithdrawals(body.Withdrawals); err != nil {
+			if err := auraEngine.ExecuteSystemWithdrawals(state, evm, body.Withdrawals); err != nil {
 				panic(err)
 			}
 		}
@@ -371,7 +371,7 @@ func (beacon *Beacon) Finalize(chain consensus.ChainHeaderReader, header *types.
 
 // FinalizeAndAssemble implements consensus.Engine, setting the final state and
 // assembling the block.
-func (beacon *Beacon) FinalizeAndAssemble(ctx context.Context, chain consensus.ChainHeaderReader, header *types.Header, state *state.StateDB, body *types.Body, receipts []*types.Receipt) (result *types.Block, err error) {
+func (beacon *Beacon) FinalizeAndAssemble(ctx context.Context, chain consensus.ChainHeaderReader, header *types.Header, state *state.StateDB, body *types.Body, receipts []*types.Receipt, evm *vm.EVM) (result *types.Block, err error) {
 	ctx, _, spanEnd := telemetry.StartSpan(ctx, "consensus.beacon.FinalizeAndAssemble",
 		telemetry.Int64Attribute("block.number", int64(header.Number.Uint64())),
 		telemetry.Int64Attribute("txs.count", int64(len(body.Transactions))),
@@ -380,7 +380,7 @@ func (beacon *Beacon) FinalizeAndAssemble(ctx context.Context, chain consensus.C
 	defer spanEnd(&err)
 
 	if !beacon.IsPoSHeader(header) {
-		block, delegateErr := beacon.ethone.FinalizeAndAssemble(ctx, chain, header, state, body, receipts)
+		block, delegateErr := beacon.ethone.FinalizeAndAssemble(ctx, chain, header, state, body, receipts, evm)
 		return block, delegateErr
 	}
 	shanghai := chain.Config().IsShanghai(header.Number, header.Time)
@@ -396,7 +396,7 @@ func (beacon *Beacon) FinalizeAndAssemble(ctx context.Context, chain consensus.C
 	}
 	// Finalize and assemble the block.
 	_, _, finalizeSpanEnd := telemetry.StartSpan(ctx, "consensus.beacon.Finalize")
-	beacon.Finalize(chain, header, state, body, receipts)
+	beacon.Finalize(chain, header, state, body, receipts, evm)
 	finalizeSpanEnd(nil)
 
 	// Assign the final state root to header.

--- a/consensus/beacon/consensus.go
+++ b/consensus/beacon/consensus.go
@@ -354,7 +354,7 @@ func (beacon *Beacon) Finalize(chain consensus.ChainHeaderReader, header *types.
 	// Withdrawals processing.
 	if auraEngine, ok := beacon.ethone.(*aura.AuRa); ok {
 		if body.Withdrawals != nil {
-			if err := auraEngine.ExecuteSystemWithdrawals(state, evm, body.Withdrawals); err != nil {
+			if err := auraEngine.ExecuteSystemWithdrawals(evm, body.Withdrawals); err != nil {
 				panic(err)
 			}
 		}

--- a/consensus/clique/clique.go
+++ b/consensus/clique/clique.go
@@ -576,18 +576,18 @@ func (c *Clique) Prepare(chain consensus.ChainHeaderReader, header *types.Header
 
 // Finalize implements consensus.Engine. There is no post-transaction
 // consensus rules in clique, do nothing here.
-func (c *Clique) Finalize(chain consensus.ChainHeaderReader, header *types.Header, state vm.StateDB, body *types.Body, _ []*types.Receipt) {
+func (c *Clique) Finalize(chain consensus.ChainHeaderReader, header *types.Header, state vm.StateDB, body *types.Body, _ []*types.Receipt, _ *vm.EVM) {
 	// No block rewards in PoA, so the state remains as is
 }
 
 // FinalizeAndAssemble implements consensus.Engine, ensuring no uncles are set,
 // nor block rewards given, and returns the final block.
-func (c *Clique) FinalizeAndAssemble(ctx context.Context, chain consensus.ChainHeaderReader, header *types.Header, state *state.StateDB, body *types.Body, receipts []*types.Receipt) (*types.Block, error) {
+func (c *Clique) FinalizeAndAssemble(ctx context.Context, chain consensus.ChainHeaderReader, header *types.Header, state *state.StateDB, body *types.Body, receipts []*types.Receipt, evm *vm.EVM) (*types.Block, error) {
 	if len(body.Withdrawals) > 0 {
 		return nil, errors.New("clique does not support withdrawals")
 	}
 	// Finalize block
-	c.Finalize(chain, header, state, body, receipts)
+	c.Finalize(chain, header, state, body, receipts, evm)
 
 	// Assign the final state root to header.
 	header.Root = state.IntermediateRoot(chain.Config().IsEIP158(header.Number))

--- a/consensus/consensus.go
+++ b/consensus/consensus.go
@@ -86,14 +86,14 @@ type Engine interface {
 	//
 	// Note: The state database might be updated to reflect any consensus rules
 	// that happen at finalization (e.g. block rewards).
-	Finalize(chain ChainHeaderReader, header *types.Header, state vm.StateDB, body *types.Body, receipts []*types.Receipt)
+	Finalize(chain ChainHeaderReader, header *types.Header, state vm.StateDB, body *types.Body, receipts []*types.Receipt, evm *vm.EVM)
 
 	// FinalizeAndAssemble runs any post-transaction state modifications (e.g. block
 	// rewards or process withdrawals) and assembles the final block.
 	//
 	// Note: The block header and state database might be updated to reflect any
 	// consensus rules that happen at finalization (e.g. block rewards).
-	FinalizeAndAssemble(ctx context.Context, chain ChainHeaderReader, header *types.Header, state *state.StateDB, body *types.Body, receipts []*types.Receipt) (*types.Block, error)
+	FinalizeAndAssemble(ctx context.Context, chain ChainHeaderReader, header *types.Header, state *state.StateDB, body *types.Body, receipts []*types.Receipt, evm *vm.EVM) (*types.Block, error)
 
 	// Seal generates a new sealing request for the given input block and pushes
 	// the result into the given channel.

--- a/consensus/ethash/consensus.go
+++ b/consensus/ethash/consensus.go
@@ -507,19 +507,19 @@ func (ethash *Ethash) Prepare(chain consensus.ChainHeaderReader, header *types.H
 }
 
 // Finalize implements consensus.Engine, accumulating the block and uncle rewards.
-func (ethash *Ethash) Finalize(chain consensus.ChainHeaderReader, header *types.Header, state vm.StateDB, body *types.Body, _ []*types.Receipt) {
+func (ethash *Ethash) Finalize(chain consensus.ChainHeaderReader, header *types.Header, state vm.StateDB, body *types.Body, _ []*types.Receipt, evm *vm.EVM) {
 	// Accumulate any block and uncle rewards
 	accumulateRewards(chain.Config(), state, header, body.Uncles)
 }
 
 // FinalizeAndAssemble implements consensus.Engine, accumulating the block and
 // uncle rewards, setting the final state and assembling the block.
-func (ethash *Ethash) FinalizeAndAssemble(ctx context.Context, chain consensus.ChainHeaderReader, header *types.Header, state *state.StateDB, body *types.Body, receipts []*types.Receipt) (*types.Block, error) {
+func (ethash *Ethash) FinalizeAndAssemble(ctx context.Context, chain consensus.ChainHeaderReader, header *types.Header, state *state.StateDB, body *types.Body, receipts []*types.Receipt, evm *vm.EVM) (*types.Block, error) {
 	if len(body.Withdrawals) > 0 {
 		return nil, errors.New("ethash does not support withdrawals")
 	}
 	// Finalize block
-	ethash.Finalize(chain, header, state, body, receipts)
+	ethash.Finalize(chain, header, state, body, receipts, evm)
 
 	// Assign the final state root to header.
 	header.Root = state.IntermediateRoot(chain.Config().IsEIP158(header.Number))

--- a/core/chain_makers.go
+++ b/core/chain_makers.go
@@ -392,14 +392,11 @@ func GenerateChain(config *params.ChainConfig, parent *types.Block, engine conse
 			misc.ApplyDAOHardFork(statedb)
 		}
 
-		var evm *vm.EVM
-		if config.IsShanghai(b.header.Number, b.header.Time) {
-			// EIP-2935
-			blockContext := NewEVMBlockContext(b.header, cm, &b.header.Coinbase)
-			blockContext.Random = &common.Hash{} // enable post-merge instruction set
-			evm = vm.NewEVM(blockContext, statedb, cm.config, vm.Config{})
-		}
+		blockContext := NewEVMBlockContext(b.header, cm, &b.header.Coinbase)
+		blockContext.Random = &common.Hash{} // enable post-merge instruction set
+		evm := vm.NewEVM(blockContext, statedb, cm.config, vm.Config{})
 		if config.IsPrague(b.header.Number, b.header.Time) || config.IsVerkle(b.header.Number, b.header.Time) {
+			// EIP-2935
 			ProcessParentBlockHash(b.header.ParentHash, evm)
 		}
 

--- a/core/chain_makers.go
+++ b/core/chain_makers.go
@@ -392,11 +392,14 @@ func GenerateChain(config *params.ChainConfig, parent *types.Block, engine conse
 			misc.ApplyDAOHardFork(statedb)
 		}
 
-		if config.IsPrague(b.header.Number, b.header.Time) || config.IsVerkle(b.header.Number, b.header.Time) {
+		var evm *vm.EVM
+		if config.IsShanghai(b.header.Number, b.header.Time) {
 			// EIP-2935
 			blockContext := NewEVMBlockContext(b.header, cm, &b.header.Coinbase)
 			blockContext.Random = &common.Hash{} // enable post-merge instruction set
-			evm := vm.NewEVM(blockContext, statedb, cm.config, vm.Config{})
+			evm = vm.NewEVM(blockContext, statedb, cm.config, vm.Config{})
+		}
+		if config.IsPrague(b.header.Number, b.header.Time) || config.IsVerkle(b.header.Number, b.header.Time) {
 			ProcessParentBlockHash(b.header.ParentHash, evm)
 		}
 
@@ -412,7 +415,7 @@ func GenerateChain(config *params.ChainConfig, parent *types.Block, engine conse
 		}
 
 		body := types.Body{Transactions: b.txs, Uncles: b.uncles, Withdrawals: b.withdrawals}
-		block, err := b.engine.FinalizeAndAssemble(context.Background(), cm, b.header, statedb, &body, b.receipts)
+		block, err := b.engine.FinalizeAndAssemble(context.Background(), cm, b.header, statedb, &body, b.receipts, evm)
 		if err != nil {
 			panic(err)
 		}

--- a/core/state_processor.go
+++ b/core/state_processor.go
@@ -147,7 +147,7 @@ func (p *StateProcessor) Process(ctx context.Context, block *types.Block, stated
 	}
 
 	// Finalize the block, applying any consensus engine specific extras (e.g. block rewards)
-	p.chain.Engine().Finalize(p.chain, header, tracingStateDB, block.Body(), receipts)
+	p.chain.Engine().Finalize(p.chain, header, tracingStateDB, block.Body(), receipts, evm)
 
 	return &ProcessResult{
 		Receipts: receipts,

--- a/internal/ethapi/simulate.go
+++ b/internal/ethapi/simulate.go
@@ -419,7 +419,7 @@ func (sim *simulator) processBlock(ctx context.Context, block *simBlock, header,
 		Withdrawals:  *block.BlockOverrides.Withdrawals,
 	}
 	chainHeadReader := &simChainHeadReader{ctx, sim.b}
-	b, err := sim.b.Engine().FinalizeAndAssemble(ctx, chainHeadReader, header, sim.state, blockBody, receipts)
+	b, err := sim.b.Engine().FinalizeAndAssemble(ctx, chainHeadReader, header, sim.state, blockBody, receipts, evm)
 	if err != nil {
 		return nil, nil, nil, err
 	}

--- a/miner/worker.go
+++ b/miner/worker.go
@@ -214,7 +214,7 @@ func (miner *Miner) generateWork(ctx context.Context, genParam *generateParams, 
 		work.header.RequestsHash = &reqHash
 	}
 
-	block, err := miner.engine.FinalizeAndAssemble(ctx, miner.chain, work.header, work.state, &body, work.receipts)
+	block, err := miner.engine.FinalizeAndAssemble(ctx, miner.chain, work.header, work.state, &body, work.receipts, work.evm)
 	if err != nil {
 		return &newPayloadResult{err: err}
 	}


### PR DESCRIPTION
Passing the syscall as a closure caused some issue as it was shared between the miner and the block processor. The same closure being used in two different contexts, meant that some unprotected map was susceptible to a race condition.

This could be fixed by adding a lock, but system contracts have also been introduced in mainline geth after this code was written. It makes sense to "modernize" this code to use a specific EVM interpreter + StateDB per context, in order to avoid said race condition.

Tentative fix for #10 .