### PR TITLE
miner: remove double state retrieval

### DIFF
--- a/miner/worker.go
+++ b/miner/worker.go
@@ -351,13 +351,9 @@ func (miner *Miner) prepareWork(ctx context.Context, genParams *generateParams, 
 
 // makeEnv creates a new environment for the sealing block.
 func (miner *Miner) makeEnv(parent *types.Header, header *types.Header, coinbase common.Address, witness bool, state *state.StateDB) (*environment, error) {
-	// Retrieve the parent state to execute on top.
-	state, err := miner.chain.StateAt(parent.Root)
-	if err != nil {
-		return nil, err
-	}
 	var bundle *stateless.Witness
 	if witness {
+		var err error
 		bundle, err = stateless.NewWitness(header, miner.chain, false)
 		if err != nil {
 			return nil, err


### PR DESCRIPTION
## Summary

  Removes the duplicate `StateAt(parent.Root)` in `miner/worker.go::makeEnv` so that the state threaded through `prepareWork` is the same instance used for block execution and state-root computation.

  ## Context

  `prepareWork` fetches `state` from the parent root and then does a few gnosis-specific things on it before handing it to `makeEnv`:

  - `SetAuraSyscall(state, ...)` — captures the state in the AuRa syscall closure
  - Balancer fork bytecode rewrite (at the transition block)
  - `miner.engine.Prepare(chain, header, state)` — AuRa `RewriteBytecode` entries, epoch handling (pre-merge only, since `Beacon.Prepare` short-circuits post-merge)

  `makeEnv` then discarded the passed-in `state` and re-read a fresh one from `parent.Root`, shadowing the parameter. Block execution, rewards, withdrawals, and `IntermediateRoot` ran against the fresh state; all
  the modifications above stayed on the orphaned state and never made it into the block.

The re-fetch was correctly deleted on v1.17.1:

Upstream `makeEnv`: https://github.com/ethereum/go-ethereum/blob/v1.17.1/miner/worker.go#L305

Gnosis v1.17.1-gc2 `makeEnv`: https://github.com/gnosischain/go-ethereum/blob/v1.17.1-gc.3/miner/worker.go#L333

However, it got added back in the v1.17.2 upstream rebase.

  ## Impact

  On the previous tag `v1.17.2-gc` (syscall closure bug exists), the shadow combined with the AuRa syscall closure meant `ExecuteSystemWithdrawals` wrote to the orphaned state while `IntermediateRoot` read the fresh one.
  Every post-Shanghai proposal had a state root missing the withdrawals, and peers rejected the block with `invalid merkle root` in `engine_newPayload`.

 **This means a validator node running v1.17.2-gc will miss the slot each time they propose with an invalid block**. This also caused all the hive tests failures

 On the current `release-1.17.2-gc` branch the syscall refactor makes the miner bug ineffective. However, the logic is still wrong on the release branch so this PR closes the logical bug.