### PR TITLE
core: fix full sync

### DIFF
--- a/core/state_processor.go
+++ b/core/state_processor.go
@@ -430,15 +430,8 @@ func AssembleBlock(engine consensus.Engine, chain consensus.ChainHeaderReader, h
 func MakeAuraSyscall(statedb vm.StateDB, context vm.BlockContext, chainConfig *params.ChainConfig, vmConfig vm.Config) aura.Syscall {
 	return func(contractaddr common.Address, data []byte) ([]byte, error) {
 		evm := vm.NewEVM(context, statedb, chainConfig, vmConfig)
-		// Pre-Amsterdam, upstream's `evm.Call` performed an unconditional
-		// `Context.Transfer` for all calls including zero-value system calls.
-		// Geth PR #33741 ("core/vm: disable the value transfer in syscall")
-		// skips that transfer for syscalls to align with the Amsterdam /
-		// EIP-7928 spec. Gnosis' pre-merge AuRa validator-set transitions
-		// (e.g. the safeContract finalizeChange at block 1301) rely on the
-		// pre-Amsterdam state-clearing side-effect of that transfer to reach
-		// the same post-state as mainnet, so replicate it here for
-		// pre-Amsterdam AuRa syscalls only.
+		// On Pre-Amsterdam blocks, explicitly call transfer even for zero-value to match pre-merge
+		// AuRa syscall behavior
 		rules := chainConfig.Rules(context.BlockNumber, context.Random != nil, context.Time)
 		if !rules.IsAmsterdam {
 			context.Transfer(statedb, params.SystemAddress, contractaddr, new(uint256.Int), &rules)

--- a/core/state_processor.go
+++ b/core/state_processor.go
@@ -430,6 +430,19 @@ func AssembleBlock(engine consensus.Engine, chain consensus.ChainHeaderReader, h
 func MakeAuraSyscall(statedb vm.StateDB, context vm.BlockContext, chainConfig *params.ChainConfig, vmConfig vm.Config) aura.Syscall {
 	return func(contractaddr common.Address, data []byte) ([]byte, error) {
 		evm := vm.NewEVM(context, statedb, chainConfig, vmConfig)
+		// Pre-Amsterdam, upstream's `evm.Call` performed an unconditional
+		// `Context.Transfer` for all calls including zero-value system calls.
+		// Geth PR #33741 ("core/vm: disable the value transfer in syscall")
+		// skips that transfer for syscalls to align with the Amsterdam /
+		// EIP-7928 spec. Gnosis' pre-merge AuRa validator-set transitions
+		// (e.g. the safeContract finalizeChange at block 1301) rely on the
+		// pre-Amsterdam state-clearing side-effect of that transfer to reach
+		// the same post-state as mainnet, so replicate it here for
+		// pre-Amsterdam AuRa syscalls only.
+		rules := chainConfig.Rules(context.BlockNumber, context.Random != nil, context.Time)
+		if !rules.IsAmsterdam {
+			context.Transfer(statedb, params.SystemAddress, contractaddr, new(uint256.Int), &rules)
+		}
 		ret, _, err := evm.Call(params.SystemAddress, contractaddr, data, vm.NewGasBudget(math.MaxUint64), new(uint256.Int))
 		if err != nil {
 			panic(err)

--- a/core/state_transition.go
+++ b/core/state_transition.go
@@ -689,14 +689,11 @@ func (st *stateTransition) execute() (*ExecutionResult, error) {
 		if overflow {
 			return nil, fmt.Errorf("invalid baseFee: %v", st.evm.Context.BaseFee)
 		}
-		effectiveTip = new(uint256.Int).Sub(msg.GasPrice, baseFee)
 
-		// Gnosis service transactions (GasFeeCap < BaseFee, IsFree()==true) reach
-		// this point with a negative effectiveTip; uint256.FromBig would wrap to
-		// near-2^256 and poison the coinbase balance. Clamp to zero so these
-		// txs contribute no tip, matching canonical OpenEthereum/Parity behavior.
-		if effectiveTip.Sign() < 0 {
+		if msg.IsFree() {
 			effectiveTip = new(uint256.Int)
+		} else {
+			effectiveTip = new(uint256.Int).Sub(msg.GasPrice, baseFee)
 		}
 	}
 

--- a/core/state_transition.go
+++ b/core/state_transition.go
@@ -690,6 +690,14 @@ func (st *stateTransition) execute() (*ExecutionResult, error) {
 			return nil, fmt.Errorf("invalid baseFee: %v", st.evm.Context.BaseFee)
 		}
 		effectiveTip = new(uint256.Int).Sub(msg.GasPrice, baseFee)
+
+		// Gnosis service transactions (GasFeeCap < BaseFee, IsFree()==true) reach
+		// this point with a negative effectiveTip; uint256.FromBig would wrap to
+		// near-2^256 and poison the coinbase balance. Clamp to zero so these
+		// txs contribute no tip, matching canonical OpenEthereum/Parity behavior.
+		if effectiveTip.Sign() < 0 {
+			effectiveTip = new(uint256.Int)
+		}
 	}
 
 	if st.evm.Config.NoBaseFee && msg.GasFeeCap.Sign() == 0 && msg.GasTipCap.Sign() == 0 {


### PR DESCRIPTION
## Problem

  Full sync from genesis on Gnosis mainnet fails with `invalid merkle root` at **block 1301** for v1.17, the first block under the `safeContract` validator set (Multi transition at block 1300):

  ```
  BAD BLOCK #########
  Block: 1301 (0xb09b9ce5…a98a33)
  Error: invalid merkle root
         (remote: b0844fca…cfd678 local: 560c49862e…404383)
  Beacon backfilling failed
  ```

  The bug has existed since the release branch included upstream commit `01fe1d716` (geth PR [#33741](https://github.com/ethereum/go-ethereum/pull/33741)) — it is present in `v1.17.1-gc` onwards and in current HEAD.
   It was not caught because:

  - **Snap sync** never re-executes pre-pivot blocks; state is copied directly from peers.

  But it breaks full sync and any replay tool that re-executes the pre-merge Gnosis chain across the AuRa safeContract transition.

  ## Root cause

  geth PR #33741 "core/vm: disable the value transfer in syscall" modified `evm.Call` to skip `Context.Transfer` when the caller is `SystemAddress`:

  ```go
  if !syscall {
      evm.Context.Transfer(evm.StateDB, caller, addr, value, &evm.chainRules)
  }
  ```

The older versions of geth put the System Address as an empty account into the state tree, and because of our Finalise logic; we never delete it.

However, when we do a full sync now with the new version; the system address never gets put into the state tree because we don't call transfer on syscalls with v1.17.
  
  ## Fix

  In `MakeAuraSyscall`, reinstate the zero-value `Context.Transfer` that the upstream PR removed, gated on `!rules.IsAmsterdam` so the post-Amsterdam EIP-7928 alignment is preserved:

  ```go
  rules := chainConfig.Rules(context.BlockNumber, context.Random != nil, context.Time)
  if !rules.IsAmsterdam {
      context.Transfer(statedb, params.SystemAddress, contractaddr, new(uint256.Int), &rules)
  }
  ```

  This restores the original side-effect (journaling SystemAddress as dirty → surviving `Finalise` via the existing SystemAddress-exclusion), producing identical block hash and allowinf gull sync.

  ## Testing

  Clean A/B testing of fix with checkpoint-synced lighthouse (`--checkpoint-sync-url https://checkpoint.gnosischain.com`)

  | Binary | Syncmode | Result |
  |---|---|---|
  | `release-1.17.2-gc` HEAD (unpatched) | `full` | BAD BLOCK at 1301, stuck at block 1300, local state root `560c4986…` |
  | `release-1.17.2-gc` + this patch | `full` | Block 1301 imports cleanly, sync continues; observed 4M+ blocks with 0 bad blocks |

  State root expected at block 1301: `0xb0844fca8b0fae91c3cca73507146df4772a6faa798ee734e69a2b90c5cfd678` (verified via Gnosis public RPC `eth_getBlockByNumber`).

  ## Scope / impact

  - **Affects:** full-sync and any replay tool (hive tests, execution-spec tests, `geth import`) that executes pre-merge Gnosis blocks crossing the block-1300 validator-set transition.