### PR TITLE
core: clamp negative effectiveTip to zero for service txs

### DIFF
--- a/core/state_transition.go
+++ b/core/state_transition.go
@@ -576,6 +576,13 @@ func (st *stateTransition) execute() (*ExecutionResult, error) {
 	effectiveTip := msg.GasPrice
 	if rules.IsLondon {
 		effectiveTip = new(big.Int).Sub(msg.GasPrice, st.evm.Context.BaseFee)
+		// Gnosis service transactions (GasFeeCap < BaseFee, IsFree()==true) reach
+		// this point with a negative effectiveTip; uint256.FromBig would wrap to
+		// near-2^256 and poison the coinbase balance. Clamp to zero so these
+		// txs contribute no tip, matching canonical OpenEthereum/Parity behavior.
+		if effectiveTip.Sign() < 0 {
+			effectiveTip = new(big.Int)
+		}
 	}
 	effectiveTipU256, _ := uint256.FromBig(effectiveTip)
 


### PR DESCRIPTION
Service transactions (gasPrice=0) post-London produce a negative effectiveTip (gasPrice - baseFee = -baseFee). 

Converting that to uint256 via uint256.FromBig wraps to 2^256 - baseFee, which then gets credited to the coinbase and corrupts state.

This clamps effectiveTip to zero when negative, so service txs contribute no tip to the coinbase (matching expected behavior).

Fixes the block 19040016 regression observed on Gnosis mainnet.

Pulled out second discovered issue in https://github.com/gnosischain/go-ethereum/pull/29 into its own isolated PR