### PR TITLE
core/state: restore deleteEmptyObjects in commit, add SystemAddress preservation test

### DIFF
--- a/core/state/statedb.go
+++ b/core/state/statedb.go
@@ -1216,7 +1216,7 @@ func (s *StateDB) commit(deleteEmptyObjects bool, noStorageWiping bool, blockNum
 		return nil, fmt.Errorf("commit aborted due to earlier error: %v", s.dbErr)
 	}
 	// Finalize any pending changes and merge everything into the tries
-	s.IntermediateRoot(false) // TODO double check this is necessary
+	s.IntermediateRoot(deleteEmptyObjects)
 
 	// Short circuit if any error occurs within the IntermediateRoot.
 	if s.dbErr != nil {

--- a/core/state/statedb_test.go
+++ b/core/state/statedb_test.go
@@ -36,6 +36,7 @@ import (
 	"github.com/ethereum/go-ethereum/core/tracing"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/crypto"
+	"github.com/ethereum/go-ethereum/params"
 	"github.com/ethereum/go-ethereum/rlp"
 	"github.com/ethereum/go-ethereum/trie"
 	"github.com/ethereum/go-ethereum/trie/trienode"
@@ -1367,4 +1368,48 @@ func TestStorageDirtiness(t *testing.T) {
 	// the storage change is reverted, dirty value should be set back
 	state.RevertToSnapshot(snap)
 	checkDirty(common.Hash{0x1}, common.Hash{0x1}, true)
+}
+
+// TestSystemAddressPreservedOnCommit verifies that the SystemAddress is not
+// deleted when committing with deleteEmptyObjects=true, even though it is
+// empty. Regular empty accounts should still be deleted. This is required for
+// Gnosis AuRa consensus which uses the SystemAddress for system calls.
+func TestSystemAddressPreservedOnCommit(t *testing.T) {
+	db := NewDatabaseForTesting()
+	state, _ := New(types.EmptyRootHash, db)
+
+	regularAddr := common.HexToAddress("0x1234567890123456789012345678901234567890")
+
+	// Touch both accounts so they exist in state as empty objects.
+	state.CreateAccount(regularAddr)
+	state.CreateAccount(params.SystemAddress)
+
+	// Sanity: both should exist before commit.
+	if !state.Exist(regularAddr) {
+		t.Fatal("regular account should exist before commit")
+	}
+	if !state.Exist(params.SystemAddress) {
+		t.Fatal("SystemAddress should exist before commit")
+	}
+
+	// Commit with deleteEmptyObjects = true.
+	root, err := state.Commit(0, true, false)
+	if err != nil {
+		t.Fatalf("commit failed: %v", err)
+	}
+
+	// Reload state from the committed root.
+	state, err = New(root, db)
+	if err != nil {
+		t.Fatalf("failed to reopen state: %v", err)
+	}
+
+	// Regular empty account must be gone.
+	if state.Exist(regularAddr) {
+		t.Fatal("empty regular account should have been deleted")
+	}
+	// SystemAddress must survive.
+	if !state.Exist(params.SystemAddress) {
+		t.Fatal("SystemAddress should NOT be deleted even when empty")
+	}
 }


### PR DESCRIPTION
## Summary

Restores upstream behaviour of \`deleteEmptyObjects\` in \`statedb.commit\` (the previous \`else if\` branch had been skipping empty-object deletion to protect the \`SystemAddress\`, but \`SystemAddress\` is already excluded from deletion higher up in \`statedb.Finalise\`). The TODO in the code already hinted at this.

Without this change, calculated state root hashes drift from the test fixtures on every commit that touches an empty account, causing integration test failures.

Adds a regression test (\`TestSystemAddressPreservedOnCommit\`) that constructs an empty \`SystemAddress\` account, runs commit with \`deleteEmptyObjects=true\`, and asserts the account is still present.

Split out from #21.

## Test plan

- [x] \`go test ./core/state/... -run SystemAddress\` passes
- [x] \`go test ./core/state/...\` passes