### PR TITLE
core/forkid: gate POA reward contract block hack on gnosis chain id

### DIFF
--- a/core/forkid/forkid.go
+++ b/core/forkid/forkid.go
@@ -292,13 +292,16 @@ func gatherForks(config *params.ChainConfig, genesis uint64) ([]uint64, []uint64
 	for len(forksByTime) > 0 && forksByTime[0] <= genesis {
 		forksByTime = forksByTime[1:]
 	}
-	// hack-insert the poa reward contract block
-	var hackedForksByBlock []uint64
-	for i := range forksByBlock {
-		if i > 0 && forksByBlock[i-1] < 9186425 && forksByBlock[i] > 9186425 {
-			hackedForksByBlock = append(hackedForksByBlock, 9186425)
+	// hack-insert the poa reward contract block (Gnosis chain ID 100 only)
+	if config.ChainID != nil && config.ChainID.Uint64() == 100 {
+		var hackedForksByBlock []uint64
+		for i := range forksByBlock {
+			if i > 0 && forksByBlock[i-1] < 9186425 && forksByBlock[i] > 9186425 {
+				hackedForksByBlock = append(hackedForksByBlock, 9186425)
+			}
+			hackedForksByBlock = append(hackedForksByBlock, forksByBlock[i])
 		}
-		hackedForksByBlock = append(hackedForksByBlock, forksByBlock[i])
+		return hackedForksByBlock, forksByTime
 	}
-	return hackedForksByBlock, forksByTime
+	return forksByBlock, forksByTime
 }


### PR DESCRIPTION
## Summary

Gates the Gnosis-specific POA reward contract block (`9186425`) insertion in `gatherForks` behind a chain-ID check (`ChainID == 100`).

Before this change, the hack ran unconditionally whenever `gatherForks` was called, which meant the forkid for Chiado and any other chain sharing this code path was being polluted with a Gnosis-mainnet-only fork block. After this change, the hack only fires on Gnosis mainnet; other chains return the unmodified `forksByBlock` slice.

Split out from #21.

## Test plan

- [x] \`go test ./core/forkid/...\` passes