### PR TITLE
consensus/aura: remove MakeAuraSyscall

### DIFF
--- a/consensus/aura/aura.go
+++ b/consensus/aura/aura.go
@@ -486,13 +486,17 @@ func (c *AuRa) VerifyUncles(chain consensus.ChainReader, header *types.Block) er
 // Prepare implements consensus.Engine, preparing all the consensus fields of the
 // header for running the transactions on top.
 func (c *AuRa) Prepare(chain consensus.ChainHeaderReader, header *types.Header, statedb *state.StateDB) error {
+	return nil
+}
+
+func (c *AuRa) AuraPrepare(chainConfig *params.ChainConfig, header *types.Header, statedb *state.StateDB) error {
 	blockNum := header.Number.Uint64()
 	for address, rewrittenCode := range c.cfg.RewriteBytecode[blockNum] {
 		statedb.SetCode(address, rewrittenCode, tracing.CodeChangeContractCreation)
 	}
 
 	c.certifierLock.Lock()
-	if c.cfg.Registrar != nil && c.certifier == nil && chain.Config().IsLondon(header.Number) {
+	if c.cfg.Registrar != nil && c.certifier == nil && chainConfig.IsLondon(header.Number) {
 		c.certifier = getCertifier(*c.cfg.Registrar, c.Syscall)
 	}
 	c.certifierLock.Unlock()

--- a/consensus/aura/aura.go
+++ b/consensus/aura/aura.go
@@ -252,7 +252,18 @@ func epochTransitionFor(chain consensus.ChainHeaderReader, e *NonTransactionalEp
 	return EpochTransition{BlockNumber: num, BlockHash: hash, ProofRlp: transitionProof}, true
 }
 
-type Syscall func(common.Address, []byte) ([]byte, error)
+func systemCall(evm *vm.EVM, contractAddr common.Address, data []byte) ([]byte, error) {
+	rules := evm.ChainConfig().Rules(evm.Context.BlockNumber, evm.Context.Random != nil, evm.Context.Time)
+	if !rules.IsAmsterdam {
+		evm.Context.Transfer(evm.StateDB, params.SystemAddress, contractAddr, new(uint256.Int), &rules)
+	}
+	ret, _, err := evm.Call(params.SystemAddress, contractAddr, data, vm.NewGasBudget(math.MaxUint64), new(uint256.Int))
+	if err != nil {
+		panic(err)
+	}
+	evm.StateDB.Finalise(true)
+	return ret, err
+}
 
 // AuRa
 // nolint
@@ -271,8 +282,6 @@ type AuRa struct {
 
 	certifier     *common.Address // certifies service transactions
 	certifierLock sync.RWMutex
-
-	Syscall Syscall
 }
 
 func SortedKeys[K constraints.Ordered, V any](m map[K]V) []K {
@@ -489,15 +498,15 @@ func (c *AuRa) Prepare(chain consensus.ChainHeaderReader, header *types.Header, 
 	return nil
 }
 
-func (c *AuRa) AuraPrepare(chainConfig *params.ChainConfig, header *types.Header, statedb *state.StateDB) error {
+func (c *AuRa) AuraPrepare(evm *vm.EVM, header *types.Header) error {
 	blockNum := header.Number.Uint64()
 	for address, rewrittenCode := range c.cfg.RewriteBytecode[blockNum] {
-		statedb.SetCode(address, rewrittenCode, tracing.CodeChangeContractCreation)
+		evm.StateDB.SetCode(address, rewrittenCode, tracing.CodeChangeContractCreation)
 	}
 
 	c.certifierLock.Lock()
-	if c.cfg.Registrar != nil && c.certifier == nil && chainConfig.IsLondon(header.Number) {
-		c.certifier = getCertifier(*c.cfg.Registrar, c.Syscall)
+	if c.cfg.Registrar != nil && c.certifier == nil && evm.ChainConfig().IsLondon(header.Number) {
+		c.certifier = getCertifier(*c.cfg.Registrar, evm)
 	}
 	c.certifierLock.Unlock()
 
@@ -522,7 +531,7 @@ func (c *AuRa) AuraPrepare(chainConfig *params.ChainConfig, header *types.Header
 	if !isEpochBegin {
 		return nil
 	}
-	return c.cfg.Validators.onEpochBegin(isEpochBegin, header, c.Syscall)
+	return c.cfg.Validators.onEpochBegin(header, evm)
 	// check_and_lock_block -> check_epoch_end_signal END (before enact)
 }
 

--- a/consensus/aura/aura.go
+++ b/consensus/aura/aura.go
@@ -498,7 +498,23 @@ func (c *AuRa) Prepare(chain consensus.ChainHeaderReader, header *types.Header, 
 	return nil
 }
 
-func (c *AuRa) AuraPrepare(evm *vm.EVM, header *types.Header) error {
+func (c *AuRa) AuraPrepare(evm *vm.EVM, header *types.Header, chain consensus.ChainHeaderReader) error {
+	// Rewrite balancer hack reversion hardfork
+	if evm.ChainConfig().Aura.BalancerRewriteAddress != nil && evm.ChainConfig().IsBalancer(header.Number, header.Time) {
+		parent := chain.GetHeaderByHash(header.ParentHash)
+		if parent == nil {
+			panic("couldn't find parent when trying to apply code rewrite")
+		}
+		// rewrite the code at the transition boundary
+		if !evm.ChainConfig().IsBalancer(parent.Number, parent.Time) {
+			evm.StateDB.SetCode(*evm.ChainConfig().Aura.BalancerRewriteAddress, evm.ChainConfig().Aura.BalancerRewriteCode[:], tracing.CodeChangeUnspecified)
+			// Extra address, used for testing
+			if evm.ChainConfig().Aura.BalancerTestRewriteAddress != nil {
+				evm.StateDB.SetCode(*evm.ChainConfig().Aura.BalancerTestRewriteAddress, evm.ChainConfig().Aura.BalancerRewriteCode[:], tracing.CodeChangeUnspecified)
+			}
+		}
+	}
+
 	blockNum := header.Number.Uint64()
 	for address, rewrittenCode := range c.cfg.RewriteBytecode[blockNum] {
 		evm.StateDB.SetCode(address, rewrittenCode, tracing.CodeChangeContractCreation)

--- a/consensus/aura/aura.go
+++ b/consensus/aura/aura.go
@@ -173,7 +173,7 @@ func (e *EpochManager) noteNewEpoch() { e.force = true }
 // zoomValidators - Zooms to the epoch after the header with the given hash. Returns true if succeeded, false otherwise.
 // It's analog of zoom_to_after function in OE, but doesn't require external locking
 // nolint
-func (e *EpochManager) zoomToAfter(chain consensus.ChainHeaderReader, er *NonTransactionalEpochReader, validators ValidatorSet, hash common.Hash, evm *vm.EVM) (*RollingFinality, uint64, bool) {
+func (e *EpochManager) zoomToAfter(chain consensus.ChainHeaderReader, er *NonTransactionalEpochReader, validators ValidatorSet, hash common.Hash, evm *vm.EVM) bool {
 	var lastWasParent bool
 	if e.finalityChecker.lastPushed != nil {
 		lastWasParent = *e.finalityChecker.lastPushed == hash
@@ -182,7 +182,7 @@ func (e *EpochManager) zoomToAfter(chain consensus.ChainHeaderReader, er *NonTra
 	// early exit for current target == chain head, but only if the epochs are
 	// the same.
 	if lastWasParent && !e.force {
-		return e.finalityChecker, e.epochTransitionNumber, true
+		return true
 	}
 	e.force = false
 
@@ -195,7 +195,7 @@ func (e *EpochManager) zoomToAfter(chain consensus.ChainHeaderReader, er *NonTra
 		if lastTransition.BlockNumber > DEBUG_LOG_FROM {
 			fmt.Printf("zoom1: %d\n", lastTransition.BlockNumber)
 		}
-		return e.finalityChecker, e.epochTransitionNumber, false
+		return false
 	}
 
 	// extract other epoch set if it's not the same as the last.
@@ -227,7 +227,7 @@ func (e *EpochManager) zoomToAfter(chain consensus.ChainHeaderReader, er *NonTra
 
 	e.epochTransitionHash = lastTransition.BlockHash
 	e.epochTransitionNumber = lastTransition.BlockNumber
-	return e.finalityChecker, e.epochTransitionNumber, true
+	return true
 }
 
 // / Get the transition to the epoch the given parent hash is part of
@@ -536,7 +536,7 @@ func (c *AuRa) AuraPrepare(evm *vm.EVM, header *types.Header) error {
 }
 
 func (c *AuRa) ApplyRewards(header *types.Header, state vm.StateDB, evm *vm.EVM) error {
-	rewards, err := c.CalculateRewards(nil, header, nil, evm)
+	rewards, err := c.CalculateRewards(header, evm)
 	if err != nil {
 		return err
 	}
@@ -587,7 +587,7 @@ func (c *AuRa) Finalize(chain consensus.ChainHeaderReader, header *types.Header,
 
 func buildFinality(e *EpochManager, chain consensus.ChainHeaderReader, er *NonTransactionalEpochReader, validators ValidatorSet, header *types.Header, evm *vm.EVM) []unAssembledHeader {
 	// commit_block -> aura.build_finality
-	_, _, ok := e.zoomToAfter(chain, er, validators, header.ParentHash, evm)
+	ok := e.zoomToAfter(chain, er, validators, header.ParentHash, evm)
 	if !ok {
 		return []unAssembledHeader{}
 	}
@@ -804,7 +804,7 @@ func (c *AuRa) APIs(chain consensus.ChainHeaderReader) []rpc.API {
 	return []rpc.API{}
 }
 
-func (c *AuRa) CalculateRewards(_ *params.ChainConfig, header *types.Header, _ []*types.Header, evm *vm.EVM) ([]consensus.Reward, error) {
+func (c *AuRa) CalculateRewards(header *types.Header, evm *vm.EVM) ([]consensus.Reward, error) {
 	var rewardContractAddress BlockRewardContract
 	var foundContract bool
 	for _, c := range c.cfg.BlockRewardContractTransitions {

--- a/consensus/aura/aura.go
+++ b/consensus/aura/aura.go
@@ -273,8 +273,6 @@ type AuRa struct {
 	certifierLock sync.RWMutex
 
 	Syscall Syscall
-
-	isPos bool
 }
 
 func SortedKeys[K constraints.Ordered, V any](m map[K]V) []K {
@@ -702,7 +700,7 @@ func (c *AuRa) Authorize(signer common.Address) {
 }
 
 func (c *AuRa) GenesisEpochData(header *types.Header) ([]byte, error) {
-	setProof, err := c.cfg.Validators.genesisEpochData(header, c.Syscall)
+	setProof, err := c.cfg.Validators.genesisEpochData(header)
 	if err != nil {
 		return nil, err
 	}
@@ -856,10 +854,6 @@ func (c *AuRa) ExecuteSystemWithdrawals(evm *vm.EVM, withdrawals []*types.Withdr
 
 	_, _, err = evm.Call(params.SystemAddress, *c.cfg.WithdrawalContractAddress, packed, vm.NewGasBudget(math.MaxUint64), new(uint256.Int))
 	return err
-}
-
-func (c *AuRa) SetMerged(merged bool) {
-	c.isPos = merged
 }
 
 // An empty step message that is included in a seal, the only difference is that it doesn't include

--- a/consensus/aura/config.go
+++ b/consensus/aura/config.go
@@ -31,12 +31,12 @@ func newValidatorSetFromJson(j *params.ValidatorSetJson, posdaoTransition *uint6
 		return &SimpleList{validators: j.List}
 	}
 	if j.SafeContract != nil {
-		return NewValidatorSafeContract(*j.SafeContract, posdaoTransition, nil)
+		return NewValidatorSafeContract(*j.SafeContract, posdaoTransition)
 	}
 	if j.Contract != nil {
 		return &ValidatorContract{
 			contractAddress:  *j.Contract,
-			validators:       NewValidatorSafeContract(*j.Contract, posdaoTransition, nil),
+			validators:       NewValidatorSafeContract(*j.Contract, posdaoTransition),
 			posdaoTransition: posdaoTransition,
 		}
 	}

--- a/consensus/aura/contract_abi.go
+++ b/consensus/aura/contract_abi.go
@@ -80,13 +80,13 @@ func withdrawalAbi() abi.ABI {
 	return a
 }
 
-func getCertifier(registrar common.Address, syscall Syscall) *common.Address {
+func getCertifier(registrar common.Address, evm *vm.EVM) *common.Address {
 	hashedKey := crypto.Keccak256Hash([]byte("service_transaction_checker"))
 	packed, err := registrarAbi().Pack("getAddress", hashedKey, "A")
 	if err != nil {
 		panic(err)
 	}
-	out, err := syscall(registrar, packed)
+	out, err := systemCall(evm, registrar, packed)
 	if err != nil {
 		panic(err)
 	}

--- a/consensus/aura/validators.go
+++ b/consensus/aura/validators.go
@@ -21,26 +21,6 @@ import (
 	"github.com/holiman/uint256"
 )
 
-// nolint
-type CallResults struct {
-	data      []byte
-	proof     [][]byte
-	execError string
-}
-
-// Type alias for a function we can make calls through synchronously.
-// Returns the call result and state proof for each call.
-type Call func(common.Address, []byte) (CallResults, error)
-
-// A system-calling closure. Enacts calls on a block's state from the system address.
-type SystemCall func(common.Address, []byte) (CallResults, error)
-
-type client interface {
-	CallAtBlockHash(common.Hash, common.Address, []byte) (CallResults, error)
-	CallAtLatestBlock(common.Address, []byte) (CallResults, error)
-	SystemCallAtBlockHash(blockHash common.Hash, contract common.Address, data []byte) (CallResults, error)
-}
-
 type ValidatorSet interface {
 	// Signalling that a new epoch has begun.
 	//
@@ -48,8 +28,7 @@ type ValidatorSet interface {
 	// and will have an effect on the block's state.
 	// The caller provided here may not generate proofs.
 	//
-	// `first` is true if this is the first block in the set.
-	onEpochBegin(firstInEpoch bool, header *types.Header, caller Syscall) error
+	onEpochBegin(header *types.Header, evm *vm.EVM) error
 
 	// Draws a validator nonce modulo number of validators.
 	// getWithCaller(parentHash common.Hash, nonce uint, caller consensus.Call) (common.Address, error)
@@ -213,9 +192,9 @@ func (s *Multi) genesisEpochData(header *types.Header) ([]byte, error) {
 	return set.genesisEpochData(header)
 }
 
-func (s *Multi) onEpochBegin(_ bool, header *types.Header, caller Syscall) error {
-	setTransition, set := s.correctSetByNumber(header.Number.Uint64())
-	return set.onEpochBegin(setTransition == header.Number.Uint64(), header, caller)
+func (s *Multi) onEpochBegin(header *types.Header, evm *vm.EVM) error {
+	_, set := s.correctSetByNumber(header.Number.Uint64())
+	return set.onEpochBegin(header, evm)
 }
 func (s *Multi) signalEpochEnd(_ bool, header *types.Header, r types.Receipts) ([]byte, error) {
 	num := header.Number.Uint64()
@@ -231,7 +210,7 @@ type SimpleList struct {
 func (s *SimpleList) epochSet(bool, uint64, []byte, *vm.EVM) (SimpleList, common.Hash, error) {
 	return *s, common.Hash{}, nil
 }
-func (s *SimpleList) onEpochBegin(bool, *types.Header, Syscall) error {
+func (s *SimpleList) onEpochBegin(*types.Header, *vm.EVM) error {
 	return nil
 }
 
@@ -260,11 +239,10 @@ type ValidatorSafeContract struct {
 	// with POSDAO modifications.
 	posdaoTransition *uint64
 
-	abi    abi.ABI
-	client client
+	abi abi.ABI
 }
 
-func NewValidatorSafeContract(contractAddress common.Address, posdaoTransition *uint64, client client) *ValidatorSafeContract {
+func NewValidatorSafeContract(contractAddress common.Address, posdaoTransition *uint64) *ValidatorSafeContract {
 	const MemoizeCapacity = 500
 	c, err := lru.New[common.Hash, *SimpleList](MemoizeCapacity)
 	if err != nil {
@@ -379,9 +357,9 @@ func (s *ValidatorSafeContract) genesisEpochData(header *types.Header) ([]byte, 
 	return rlp.EncodeToBytes(FirstValidatorSetProof{Header: header, ContractAddress: s.contractAddress})
 }
 
-func (s *ValidatorSafeContract) onEpochBegin(firstInEpoch bool, header *types.Header, caller Syscall) error {
+func (s *ValidatorSafeContract) onEpochBegin(header *types.Header, evm *vm.EVM) error {
 	data := common.FromHex("75286211") // s.abi.Pack("finalizeChange")
-	_, err := caller(s.contractAddress, data)
+	_, err := systemCall(evm, s.contractAddress, data)
 	if err != nil {
 		return err
 	}
@@ -543,8 +521,8 @@ func (s *ValidatorContract) epochSet(firstInEpoch bool, num uint64, proof []byte
 	return s.validators.epochSet(firstInEpoch, num, proof, evm)
 }
 
-func (s *ValidatorContract) onEpochBegin(firstInEpoch bool, header *types.Header, caller Syscall) error {
-	return s.validators.onEpochBegin(firstInEpoch, header, caller)
+func (s *ValidatorContract) onEpochBegin(header *types.Header, evm *vm.EVM) error {
+	return s.validators.onEpochBegin(header, evm)
 }
 func (s *ValidatorContract) genesisEpochData(header *types.Header) ([]byte, error) {
 	return s.validators.genesisEpochData(header)

--- a/consensus/aura/validators.go
+++ b/consensus/aura/validators.go
@@ -67,7 +67,7 @@ type ValidatorSet interface {
 	epochSet(firstInEpoch bool, num uint64, setProof []byte, evm *vm.EVM) (SimpleList, common.Hash, error)
 
 	// Extract genesis epoch data from the genesis state and header.
-	genesisEpochData(header *types.Header, call Syscall) ([]byte, error)
+	genesisEpochData(header *types.Header) ([]byte, error)
 
 	/*
 	 // Returns the current number of validators.
@@ -208,9 +208,9 @@ func (s *Multi) epochSet(firstInEpoch bool, num uint64, proof []byte, evm *vm.EV
 	firstInEpoch = setBlock == num
 	return set.epochSet(firstInEpoch, num, proof, evm)
 }
-func (s *Multi) genesisEpochData(header *types.Header, call Syscall) ([]byte, error) {
+func (s *Multi) genesisEpochData(header *types.Header) ([]byte, error) {
 	_, set := s.correctSetByNumber(0)
-	return set.genesisEpochData(header, call)
+	return set.genesisEpochData(header)
 }
 
 func (s *Multi) onEpochBegin(_ bool, header *types.Header, caller Syscall) error {
@@ -235,7 +235,7 @@ func (s *SimpleList) onEpochBegin(bool, *types.Header, Syscall) error {
 	return nil
 }
 
-func (s *SimpleList) genesisEpochData(*types.Header, Syscall) ([]byte, error) {
+func (s *SimpleList) genesisEpochData(*types.Header) ([]byte, error) {
 	return []byte{}, nil
 }
 
@@ -375,7 +375,7 @@ func (s *ValidatorSafeContract) getListSyscall(evm *vm.EVM) (*SimpleList, bool) 
 	return NewSimpleList(out0), true
 }
 
-func (s *ValidatorSafeContract) genesisEpochData(header *types.Header, call Syscall) ([]byte, error) {
+func (s *ValidatorSafeContract) genesisEpochData(header *types.Header) ([]byte, error) {
 	return rlp.EncodeToBytes(FirstValidatorSetProof{Header: header, ContractAddress: s.contractAddress})
 }
 
@@ -546,8 +546,8 @@ func (s *ValidatorContract) epochSet(firstInEpoch bool, num uint64, proof []byte
 func (s *ValidatorContract) onEpochBegin(firstInEpoch bool, header *types.Header, caller Syscall) error {
 	return s.validators.onEpochBegin(firstInEpoch, header, caller)
 }
-func (s *ValidatorContract) genesisEpochData(header *types.Header, call Syscall) ([]byte, error) {
-	return s.validators.genesisEpochData(header, call)
+func (s *ValidatorContract) genesisEpochData(header *types.Header) ([]byte, error) {
+	return s.validators.genesisEpochData(header)
 }
 func (s *ValidatorContract) signalEpochEnd(firstInEpoch bool, header *types.Header, r types.Receipts) ([]byte, error) {
 	return s.validators.signalEpochEnd(firstInEpoch, header, r)

--- a/consensus/beacon/consensus.go
+++ b/consensus/beacon/consensus.go
@@ -444,10 +444,10 @@ func (beacon *Beacon) SetThreads(threads int) {
 	}
 }
 
-func (beacon *Beacon) AuraPrepare(evm *vm.EVM, header *types.Header) error {
+func (beacon *Beacon) AuraPrepare(evm *vm.EVM, header *types.Header, chain consensus.ChainHeaderReader) error {
 	ethone, ok := beacon.ethone.(*aura.AuRa)
 	if !ok {
 		panic("AuraPrepare called in a non-Aura context")
 	}
-	return ethone.AuraPrepare(evm, header)
+	return ethone.AuraPrepare(evm, header, chain)
 }

--- a/consensus/beacon/consensus.go
+++ b/consensus/beacon/consensus.go
@@ -450,10 +450,11 @@ func (beacon *Beacon) SetAuraSyscall(sc aura.Syscall) {
 	}
 }
 
-func (beacon *Beacon) AuraPrepare(chain consensus.ChainHeaderReader, header *types.Header, statedb *state.StateDB) {
+func (beacon *Beacon) AuraPrepare(chainConfig *params.ChainConfig, header *types.Header, statedb *state.StateDB) error {
 	// mark down if the current chain has merged
-	if _, ok := beacon.ethone.(*aura.AuRa); !ok {
+	ethone, ok := beacon.ethone.(*aura.AuRa)
+	if !ok {
 		panic("AuraPrepare called in a non-Aura context")
 	}
-	beacon.ethone.Prepare(chain, header, statedb)
+	return ethone.AuraPrepare(chainConfig, header, statedb)
 }

--- a/consensus/beacon/consensus.go
+++ b/consensus/beacon/consensus.go
@@ -444,17 +444,10 @@ func (beacon *Beacon) SetThreads(threads int) {
 	}
 }
 
-func (beacon *Beacon) SetAuraSyscall(sc aura.Syscall) {
-	if a, ok := beacon.ethone.(*aura.AuRa); ok {
-		a.Syscall = sc
-	}
-}
-
-func (beacon *Beacon) AuraPrepare(chainConfig *params.ChainConfig, header *types.Header, statedb *state.StateDB) error {
-	// mark down if the current chain has merged
+func (beacon *Beacon) AuraPrepare(evm *vm.EVM, header *types.Header) error {
 	ethone, ok := beacon.ethone.(*aura.AuRa)
 	if !ok {
 		panic("AuraPrepare called in a non-Aura context")
 	}
-	return ethone.AuraPrepare(chainConfig, header, statedb)
+	return ethone.AuraPrepare(evm, header)
 }

--- a/consensus/beacon/consensus.go
+++ b/consensus/beacon/consensus.go
@@ -452,8 +452,8 @@ func (beacon *Beacon) SetAuraSyscall(sc aura.Syscall) {
 
 func (beacon *Beacon) AuraPrepare(chain consensus.ChainHeaderReader, header *types.Header, statedb *state.StateDB) {
 	// mark down if the current chain has merged
-	if a, ok := beacon.ethone.(*aura.AuRa); ok {
-		a.SetMerged(beacon.IsPoSHeader(header))
+	if _, ok := beacon.ethone.(*aura.AuRa); !ok {
+		panic("AuraPrepare called in a non-Aura context")
 	}
 	beacon.ethone.Prepare(chain, header, statedb)
 }

--- a/core/state_processor.go
+++ b/core/state_processor.go
@@ -108,9 +108,8 @@ func (p *StateProcessor) Process(ctx context.Context, block *types.Block, stated
 					statedb.SetCode(*config.Aura.BalancerTestRewriteAddress, config.Aura.BalancerRewriteCode[:], tracing.CodeChangeUnspecified)
 				}
 			}
+			b.AuraPrepare(evm, block.Header())
 		}
-		// @chetna: you found it, you get to claim the fix
-		b.AuraPrepare(evm, block.Header())
 	}
 	if beaconRoot := block.BeaconRoot(); beaconRoot != nil {
 		ProcessBeaconBlockRoot(*beaconRoot, evm)

--- a/core/state_processor.go
+++ b/core/state_processor.go
@@ -110,9 +110,7 @@ func (p *StateProcessor) Process(ctx context.Context, block *types.Block, stated
 			}
 		}
 		// @chetna: you found it, you get to claim the fix
-		if err := b.AuraPrepare(evm, block.Header()); err != nil {
-			return nil, fmt.Errorf("error running AuRa state processor pre-STF boilerplate: %w", err)
-		}
+		b.AuraPrepare(evm, block.Header())
 	}
 	if beaconRoot := block.BeaconRoot(); beaconRoot != nil {
 		ProcessBeaconBlockRoot(*beaconRoot, evm)

--- a/core/state_processor.go
+++ b/core/state_processor.go
@@ -93,23 +93,8 @@ func (p *StateProcessor) Process(ctx context.Context, block *types.Block, stated
 	evm := vm.NewEVM(context, tracingStateDB, config, cfg)
 	defer evm.Release()
 	b, ok := p.chain.Engine().(*beacon.Beacon)
-	if ok {
-		// Balancer hack hardfork: rewrite the bytecode at the fork transition
-		if config.Aura != nil && config.Aura.BalancerRewriteAddress != nil && config.IsBalancer(block.Number(), block.Time()) {
-			parent := p.chain.GetHeaderByHash(block.ParentHash())
-			if parent == nil {
-				panic("couldn't find parent when trying to apply code rewrite")
-			}
-			// rewrite the code at the transition boundary
-			if !config.IsBalancer(parent.Number, parent.Time) {
-				statedb.SetCode(*config.Aura.BalancerRewriteAddress, config.Aura.BalancerRewriteCode[:], tracing.CodeChangeUnspecified)
-				// Extra address, used for testing
-				if config.Aura.BalancerTestRewriteAddress != nil {
-					statedb.SetCode(*config.Aura.BalancerTestRewriteAddress, config.Aura.BalancerRewriteCode[:], tracing.CodeChangeUnspecified)
-				}
-			}
-			b.AuraPrepare(evm, block.Header())
-		}
+	if ok && config.Aura != nil {
+		b.AuraPrepare(evm, block.Header(), p.chain)
 	}
 	if beaconRoot := block.BeaconRoot(); beaconRoot != nil {
 		ProcessBeaconBlockRoot(*beaconRoot, evm)

--- a/core/state_processor.go
+++ b/core/state_processor.go
@@ -19,7 +19,6 @@ package core
 import (
 	"context"
 	"fmt"
-	"math"
 	"math/big"
 
 	"github.com/ethereum/go-ethereum/common"
@@ -95,9 +94,6 @@ func (p *StateProcessor) Process(ctx context.Context, block *types.Block, stated
 	defer evm.Release()
 	b, ok := p.chain.Engine().(*beacon.Beacon)
 	if ok {
-		// XXX check this is ok
-		b.SetAuraSyscall(MakeAuraSyscall(tracingStateDB, context, config, cfg))
-
 		// Balancer hack hardfork: rewrite the bytecode at the fork transition
 		if config.Aura != nil && config.Aura.BalancerRewriteAddress != nil && config.IsBalancer(block.Number(), block.Time()) {
 			parent := p.chain.GetHeaderByHash(block.ParentHash())
@@ -113,7 +109,10 @@ func (p *StateProcessor) Process(ctx context.Context, block *types.Block, stated
 				}
 			}
 		}
-		b.AuraPrepare(p.chain, block.Header(), statedb)
+		// @chetna: you found it, you get to claim the fix
+		if err := b.AuraPrepare(config, block.Header(), statedb); err != nil {
+			return nil, fmt.Errorf("error running AuRa pre-STF boilerplate")
+		}
 	}
 	if beaconRoot := block.BeaconRoot(); beaconRoot != nil {
 		ProcessBeaconBlockRoot(*beaconRoot, evm)
@@ -425,22 +424,4 @@ func AssembleBlock(engine consensus.Engine, chain consensus.ChainHeaderReader, h
 	engine.Finalize(chain, header, state, body, receipts, evm)
 	header.Root = state.IntermediateRoot(chain.Config().IsEIP158(header.Number))
 	return types.NewBlock(header, body, receipts, trie.NewStackTrie(nil))
-}
-
-func MakeAuraSyscall(statedb vm.StateDB, context vm.BlockContext, chainConfig *params.ChainConfig, vmConfig vm.Config) aura.Syscall {
-	return func(contractaddr common.Address, data []byte) ([]byte, error) {
-		evm := vm.NewEVM(context, statedb, chainConfig, vmConfig)
-		// On Pre-Amsterdam blocks, explicitly call transfer even for zero-value to match pre-merge
-		// AuRa syscall behavior
-		rules := chainConfig.Rules(context.BlockNumber, context.Random != nil, context.Time)
-		if !rules.IsAmsterdam {
-			context.Transfer(statedb, params.SystemAddress, contractaddr, new(uint256.Int), &rules)
-		}
-		ret, _, err := evm.Call(params.SystemAddress, contractaddr, data, vm.NewGasBudget(math.MaxUint64), new(uint256.Int))
-		if err != nil {
-			panic(err)
-		}
-		statedb.Finalise(true)
-		return ret, err
-	}
 }

--- a/core/state_processor.go
+++ b/core/state_processor.go
@@ -111,7 +111,7 @@ func (p *StateProcessor) Process(ctx context.Context, block *types.Block, stated
 		}
 		// @chetna: you found it, you get to claim the fix
 		if err := b.AuraPrepare(evm, block.Header()); err != nil {
-			return nil, fmt.Errorf("error running AuRa pre-STF boilerplate")
+			return nil, fmt.Errorf("error running AuRa state processor pre-STF boilerplate: %w", err)
 		}
 	}
 	if beaconRoot := block.BeaconRoot(); beaconRoot != nil {

--- a/core/state_processor.go
+++ b/core/state_processor.go
@@ -110,7 +110,7 @@ func (p *StateProcessor) Process(ctx context.Context, block *types.Block, stated
 			}
 		}
 		// @chetna: you found it, you get to claim the fix
-		if err := b.AuraPrepare(config, block.Header(), statedb); err != nil {
+		if err := b.AuraPrepare(evm, block.Header()); err != nil {
 			return nil, fmt.Errorf("error running AuRa pre-STF boilerplate")
 		}
 	}

--- a/miner/worker.go
+++ b/miner/worker.go
@@ -327,7 +327,7 @@ func (miner *Miner) prepareWork(ctx context.Context, genParams *generateParams, 
 			evm := vm.NewEVM(context, state, miner.chainConfig, *miner.chain.GetVMConfig())
 			if err := b.AuraPrepare(evm, header); err != nil {
 				evm.Release()
-				return nil, fmt.Errorf("error running AuRa pre-STF boilerplate")
+				return nil, fmt.Errorf("error running AuRa miner pre-STF boilerplate")
 			}
 			evm.Release()
 		}

--- a/miner/worker.go
+++ b/miner/worker.go
@@ -31,7 +31,6 @@ import (
 	"github.com/ethereum/go-ethereum/core"
 	"github.com/ethereum/go-ethereum/core/state"
 	"github.com/ethereum/go-ethereum/core/stateless"
-	"github.com/ethereum/go-ethereum/core/tracing"
 	"github.com/ethereum/go-ethereum/core/txpool"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/core/vm"
@@ -313,20 +312,11 @@ func (miner *Miner) prepareWork(ctx context.Context, genParams *generateParams, 
 		}
 
 		// Balancer hack hardfork: rewrite the bytecode at the fork transition
-		if miner.chainConfig.Aura != nil && miner.chainConfig.Aura.BalancerRewriteAddress != nil && miner.chainConfig.IsBalancer(header.Number, header.Time) {
-			// rewrite the code at the transition boundary
-			if !miner.chainConfig.IsBalancer(parent.Number, parent.Time) {
-				state.SetCode(*miner.chainConfig.Aura.BalancerRewriteAddress, miner.chainConfig.Aura.BalancerRewriteCode[:], tracing.CodeChangeUnspecified)
-				// Extra address, used for testing
-				if miner.chainConfig.Aura.BalancerTestRewriteAddress != nil {
-					state.SetCode(*miner.chainConfig.Aura.BalancerTestRewriteAddress, miner.chainConfig.Aura.BalancerRewriteCode[:], tracing.CodeChangeUnspecified)
-				}
-			}
-
+		if miner.chainConfig.Aura != nil {
 			context := core.NewEVMBlockContext(header, miner.chain, nil)
 			evm := vm.NewEVM(context, state, miner.chainConfig, *miner.chain.GetVMConfig())
 			defer evm.Release()
-			b.AuraPrepare(evm, header)
+			b.AuraPrepare(evm, header, miner.chain)
 		}
 	}
 	// Run the consensus preparation with the default or customized consensus engine.

--- a/miner/worker.go
+++ b/miner/worker.go
@@ -323,9 +323,13 @@ func (miner *Miner) prepareWork(ctx context.Context, genParams *generateParams, 
 				}
 			}
 
-			if err := b.AuraPrepare(miner.chainConfig, header, state); err != nil {
+			context := core.NewEVMBlockContext(header, miner.chain, nil)
+			evm := vm.NewEVM(context, state, miner.chainConfig, *miner.chain.GetVMConfig())
+			if err := b.AuraPrepare(evm, header); err != nil {
+				evm.Release()
 				return nil, fmt.Errorf("error running AuRa pre-STF boilerplate")
 			}
+			evm.Release()
 		}
 	}
 	// Run the consensus preparation with the default or customized consensus engine.

--- a/miner/worker.go
+++ b/miner/worker.go
@@ -325,11 +325,8 @@ func (miner *Miner) prepareWork(ctx context.Context, genParams *generateParams, 
 
 			context := core.NewEVMBlockContext(header, miner.chain, nil)
 			evm := vm.NewEVM(context, state, miner.chainConfig, *miner.chain.GetVMConfig())
-			if err := b.AuraPrepare(evm, header); err != nil {
-				evm.Release()
-				return nil, fmt.Errorf("error running AuRa miner pre-STF boilerplate")
-			}
-			evm.Release()
+			defer evm.Release()
+			b.AuraPrepare(evm, header)
 		}
 	}
 	// Run the consensus preparation with the default or customized consensus engine.

--- a/miner/worker.go
+++ b/miner/worker.go
@@ -311,8 +311,6 @@ func (miner *Miner) prepareWork(ctx context.Context, genParams *generateParams, 
 		if header.Difficulty == nil {
 			header.Difficulty = common.Big0
 		}
-		context := core.NewEVMBlockContext(header, miner.chain, nil)
-		b.SetAuraSyscall(core.MakeAuraSyscall(state, context, miner.chainConfig, *miner.chain.GetVMConfig()))
 
 		// Balancer hack hardfork: rewrite the bytecode at the fork transition
 		if miner.chainConfig.Aura != nil && miner.chainConfig.Aura.BalancerRewriteAddress != nil && miner.chainConfig.IsBalancer(header.Number, header.Time) {
@@ -323,6 +321,10 @@ func (miner *Miner) prepareWork(ctx context.Context, genParams *generateParams, 
 				if miner.chainConfig.Aura.BalancerTestRewriteAddress != nil {
 					state.SetCode(*miner.chainConfig.Aura.BalancerTestRewriteAddress, miner.chainConfig.Aura.BalancerRewriteCode[:], tracing.CodeChangeUnspecified)
 				}
+			}
+
+			if err := b.AuraPrepare(miner.chainConfig, header, state); err != nil {
+				return nil, fmt.Errorf("error running AuRa pre-STF boilerplate")
 			}
 		}
 	}


### PR DESCRIPTION
This PR reorders the functions that execute the block prologue in the Aura consensus engine. Previously, some weird tweaks were made in order to make sure that the execution context was available to the system calls executing before the canonical Ethereum transition function. It was trying to force the use of the `Prepare` function of geth's consensus engine interface.

The thesis of this PR is that the interface isn't designed for block prologues like the one required in Aura, and therefore it no longer tries to force its use. Instead, it acknowledges `AuraPrepare` as a special case - and it fixes all the relevant call sites. It also recognizes that since Cancun, an execution environment is always available to the block producer/verifier, so it uses that environment to make prologue syscalls.

Another insight from this PR, is that gnosis chain doesn't make full usage of all aura capabilities, and therefore the amount of code required is much lower. As a result, a great deal of code has been deleted - and the interfaces have been simplified as a consequence.

TODO:

 - [x] basic chain follow
 - [x] test block production
 - [x] verify that a fullsync can still be achieved
 - [x] complete interface simplification
 - [x] fix tests