### PR TITLE
consensus/aura, core/rawdb: rework db epoch access + reactivate genesis test

### DIFF
--- a/consensus/aura/aura.go
+++ b/consensus/aura/aura.go
@@ -26,7 +26,6 @@ import (
 	"math"
 	"math/big"
 	"sort"
-	"strings"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -698,11 +697,7 @@ func isEpochEnd(chain consensus.ChainHeaderReader, e *NonTransactionalEpochReade
 	// commit_block -> aura.is_epoch_end
 	for i := range finalized {
 		pendingTransitionProof, err := e.GetPendingEpoch(finalized[i].hash, finalized[i].number)
-		// GNOSIS: pebble returns an error when a non-existent value
-		// isn't found, which is what happens at genesis.
-		// using raw string to remove pebble import which was breaking
-		// cmd/keeper build on MIPSLE target
-		if err != nil && !strings.Contains(err.Error(), "pebble: not found") {
+		if err != nil {
 			return nil, err
 		}
 		if pendingTransitionProof == nil {

--- a/consensus/aura/aura_test.go
+++ b/consensus/aura/aura_test.go
@@ -1,56 +1,48 @@
 package aura_test
 
-// import (
-// 	"testing"
+import (
+	"testing"
 
-// 	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/require"
 
-// 	"github.com/ethereum/go-ethereum-lib/kv/memdb"
-// 	libcommon "github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/consensus/aura"
+	"github.com/ethereum/go-ethereum/consensus/beacon"
+	"github.com/ethereum/go-ethereum/core"
+	"github.com/ethereum/go-ethereum/core/rawdb"
+	"github.com/ethereum/go-ethereum/params"
+)
 
-// 	"github.com/ethereum/go-ethereum/consensus/aura"
-// 	"github.com/ethereum/go-ethereum/core"
-// 	"github.com/ethereum/go-ethereum/core/types"
-// 	"github.com/ethereum/go-ethereum/trie"
-// )
+// TestGnosisEmptyBlock checks that blocks in the shape of the first blocks of
+// Gnosis Chain, which carry no transactions and predate the block reward
+// contract (blockReward is 0 until block 1310), do not change the state root:
+// the zero-value reward paid to the validator must not leave an empty account
+// behind.
+func TestGnosisEmptyBlock(t *testing.T) {
+	const blocks = 4
 
-// Check that the first block of Gnosis Chain, which doesn't have any transactions,
-// does not change the state root.
-// func TestEmptyBlock(t *testing.T) {
-// 	require := require.New(t)
-// 	genesis := core.DefaultGnosisGenesisBlock()
-// 	genesisBlock := genesis.ToBlock()
+	genesis := core.DefaultGnosisGenesisBlock()
 
-// 	genesis.Config.TerminalTotalDifficultyPassed = false
+	engine, err := aura.NewAuRa(genesis.Config.Aura, rawdb.NewMemoryDatabase())
+	require.NoError(t, err)
+	defer engine.Close()
 
-// 	chainConfig := genesis.Config
-// 	auraDB := memdb.NewTestDB(t)
-// 	engine, err := aura.NewAuRa(chainConfig.Aura, auraDB)
-// 	require.NoError(err)
-// 	m := stages.MockWithGenesisEngine(t, genesis, engine, false)
+	// The only validator of the initial Gnosis epoch, and the author of block 1.
+	validator := common.HexToAddress("0xcace5b3c29211740e595850e80478416ee77ca21")
 
-// 	time := uint64(1539016985)
-// 	header := core.MakeEmptyHeader(genesisBlock.Header(), chainConfig, time, nil)
-// 	header.UncleHash = types.EmptyUncleHash
-// 	header.TxHash = trie.EmptyRoot
-// 	header.ReceiptHash = trie.EmptyRoot
-// 	header.Coinbase = libcommon.HexToAddress("0xcace5b3c29211740e595850e80478416ee77ca21")
-// 	header.Difficulty = engine.CalcDifficulty(nil, time,
-// 		0,
-// 		genesisBlock.Difficulty(),
-// 		genesisBlock.NumberU64(),
-// 		genesisBlock.Hash(),
-// 		genesisBlock.UncleHash(),
-// 		genesisBlock.Header().AuRaStep,
-// 	)
+	db, chain, _ := core.GenerateChainWithGenesis(genesis, beacon.New(engine), blocks, func(i int, b *core.BlockGen) {
+		b.SetCoinbase(validator)
+	})
+	for _, block := range chain {
+		require.Equal(t, params.GnosisGenesisStateRoot, block.Root(), "empty block %d changed the state root", block.NumberU64())
+	}
 
-// 	block := types.NewBlockWithHeader(header)
+	bc, err := core.NewBlockChain(db, genesis, beacon.New(engine), nil)
+	require.NoError(t, err)
+	defer bc.Stop()
 
-// 	headers, blocks, receipts := make([]*types.Header, 1), make(types.Blocks, 1), make([]types.Receipts, 1)
-// 	headers[0] = header
-// 	blocks[0] = block
-
-// 	chain := &core.ChainPack{Headers: headers, Blocks: blocks, Receipts: receipts, TopBlock: block}
-// 	err = m.InsertChain(chain)
-// 	require.NoError(err)
-// }
+	n, err := bc.InsertChain(chain)
+	require.NoError(t, err)
+	require.Equal(t, blocks, n)
+	require.Equal(t, chain[blocks-1].Hash(), bc.CurrentBlock().Hash())
+}

--- a/core/rawdb/accessors_chain_aura.go
+++ b/core/rawdb/accessors_chain_aura.go
@@ -7,11 +7,23 @@ import (
 	"github.com/ethereum/go-ethereum/ethdb"
 )
 
+// readEpochProof retrieves the proof stored under key, returning a nil proof if
+// the key is absent. Key-value backends signal a missing key with their own
+// error value (pebble, leveldb and memorydb all differ), so presence is probed
+// explicitly instead of matching on the returned error.
+func readEpochProof(db ethdb.KeyValueReader, key []byte) (transitionProof []byte, err error) {
+	ok, err := db.Has(key)
+	if err != nil || !ok {
+		return nil, err
+	}
+	return db.Get(key)
+}
+
 func ReadEpoch(db ethdb.KeyValueReader, blockNum uint64, blockHash common.Hash) (transitionProof []byte, err error) {
 	k := make([]byte, 40 /* block num uint64 + block hash */)
 	binary.BigEndian.PutUint64(k, blockNum)
 	copy(k[8:], blockHash[:])
-	return db.Get(epochKey(k))
+	return readEpochProof(db, epochKey(k))
 }
 
 // TODO use sqlite if leveldb doesn't work
@@ -54,7 +66,7 @@ func ReadPendingEpoch(db ethdb.KeyValueReader, blockNum uint64, blockHash common
 	k := make([]byte, 8+32)
 	binary.BigEndian.PutUint64(k, blockNum)
 	copy(k[8:], blockHash[:])
-	return db.Get(pendingEpochKey(k))
+	return readEpochProof(db, pendingEpochKey(k))
 }
 
 func WritePendingEpoch(db ethdb.KeyValueWriter, blockNum uint64, blockHash common.Hash, transitionProof []byte) (err error) {


### PR DESCRIPTION
Ongoing cleanup work, there is still some commented/tacky code that needs a refactor.

This uncomments a test that was inherited from erigon + better handles the absence of an epoch key in the database.